### PR TITLE
feat: shared metadata store + pull-and-cache (#60)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         stages: [pre-commit]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.0
+    rev: v0.15.12
     hooks:
       - id: ruff
         name: ruff lint

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -59,6 +59,21 @@ This reorders the brainstorm's "3 pillars" (which presented them as parallel).
 
 *(More terms added as they resolve.)*
 
+## Shared-store schema (V0)
+
+The shared metadata store (Supabase Postgres) holds **anonymous track-level facts only** — no `user_id`, no `played_at`, no play-context in any table. Migration: `supabase/migrations/20260609000000_shared_metadata.sql`. Python client: `src/music_intel_mcp/shared_store.py`. Issue #60, decision `f7a9fcbd`.
+
+Tables:
+
+- **`tracks`** — canonical identity + denormalised display facts. PK is a **canonical string id** (`mbid:…` > `isrc:…` > `spotify:…` > `name:<casefold>\x1f<casefold>`), built by `canonical_track_id()` — the same waterfall #61 formalises. Columns: `id`, `spotify_id`, `isrc`, `mbid`, `name`, `artist`, `artist_id`→artists, `fetched_at` (TTL anchor). Indexed on spotify_id/isrc/mbid for the identity waterfall.
+- **`artists`** — artist-level facts (`mbid`, `name`). Defined for #61 + future artist enrichment; V0's `TrackMetadataRecord` denormalises `artist` onto `tracks` and does not yet populate this table.
+- **`audio_features`** — one row per track (PK = `track_id`): `bpm`, `energy`, `valence`, `danceability`, `acousticness`, `instrumentalness`, `source`. All nullable (partial enrichment is valid).
+- **`tags`** — many rows per track: `(track_id, tag, weight, source)`, unique on `(track_id, tag, source)`. Scene/cultural tags from Last.fm etc.
+
+`TrackMetadataRecord` (pydantic, `extra="forbid"`) is the **pull unit** — a track's `tracks` row + its `audio_features` + its `tags`, plus `fetched_at`. `extra="forbid"` is the structural guard that personal data can never leak into a shared-store record.
+
+**Store access** is `SharedStore` (Protocol) with only **bulk** ops — `get_tracks(ids)` / `upsert_tracks(records)`; no singular getter exists, so the no-round-trip rule is enforced by the type. Implementations: `InMemorySharedStore` (real store in tests + offline fallback) and `SupabaseSharedStore` (network-only, lazy-imports the `supabase` optional extra, never run in CI). `pull_and_cache(ids, store, cache, now, ttl_days=90)` serves fresh entries from the local `MetadataCache` (`data/cache/`), collects uncached/stale ids, and fetches them in **one** bulk call; stale (past-TTL) store entries are surfaced for re-enrichment, missing ids for enrichment.
+
 ## Invariants
 
 - **Transparency.** Every insight, score, and recommendation carries its evidence chain. No opaque numbers. If we can't explain it, we don't ship it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,12 @@ pythonpath = ["src"]
 [tool.ruff]
 line-length = 100
 target-version = "py311"
+# Source roots so isort classifies the package as first-party deterministically
+# across ruff versions (otherwise local/CI can disagree on import ordering).
+src = ["src", "tests"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W", "UP", "B", "SIM"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["music_intel_mcp"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,11 @@ dev = [
   "ruff>=0.3",
   "pre-commit>=3.6",
 ]
+# Production shared-metadata store. Network-only (SupabaseSharedStore); CI uses
+# the in-memory store, so this stays out of the default/dev install.
+supabase = [
+  "supabase>=2.0",
+]
 
 [project.scripts]
 music-intel = "music_intel_mcp.cli:main"

--- a/src/music_intel_mcp/shared_store.py
+++ b/src/music_intel_mcp/shared_store.py
@@ -1,0 +1,406 @@
+"""Shared metadata store + pull-and-cache (decision f7a9fcbd, issue #60).
+
+The shared store is an **additive, multi-user-ready** database of anonymous
+track-level facts (Supabase Postgres in production). Enrichers (#61/#63/#64)
+write facts here; the analyser reads them. It holds *no* per-user data — no
+``user_id``, no ``played_at``, no play-context — so it can be shared across all
+users (more users -> more cache hits -> faster analysis for everyone).
+
+**Pull-and-cache** is the access pattern every enricher/analyser step uses:
+one *bulk* read of all tracks of interest, materialised to the local cache
+(``data/cache/<track_id>.json``), then analysis runs fully offline. Per-track
+round-trips to Supabase during analysis are forbidden — :func:`pull_and_cache`
+issues at most one :meth:`SharedStore.get_tracks` call per invocation.
+
+Freshness: each record carries ``fetched_at``; an entry older than the TTL
+(~90 days) is *stale* and re-pulled from the store (which, once an enricher
+runs, re-derives it from the source APIs).
+
+CI uses :class:`InMemorySharedStore` exclusively — no live Supabase, no network.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+from urllib.parse import quote
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .models import TrackRef
+from .store import resolve_data_root
+
+DEFAULT_TTL_DAYS = 90
+
+# Env metadata for the production Supabase client (values live in .env / host
+# env, never in the repo). Listed here so the lazy client knows what to read.
+_SUPABASE_URL_ENV = "SUPABASE_URL"
+_SUPABASE_KEY_ENV = "SUPABASE_KEY"
+
+
+# --------------------------------------------------------------------------- #
+# Canonical track identity
+# --------------------------------------------------------------------------- #
+
+
+def canonical_track_id(track: TrackRef) -> str:
+    """Stable string key for a track across the shared store and local cache.
+
+    Mirrors the identity waterfall (mbid > isrc > spotify_id > name/artist).
+    String form (the analyser's ``_track_key`` returns a tuple for counting);
+    #61 unifies the two when identity resolution lands.
+    """
+    if track.mbid:
+        return f"mbid:{track.mbid}"
+    if track.isrc:
+        return f"isrc:{track.isrc}"
+    if track.spotify_id:
+        return f"spotify:{track.spotify_id}"
+    return f"name:{track.name.casefold()}\x1f{track.artist.casefold()}"
+
+
+# --------------------------------------------------------------------------- #
+# Records — anonymous track-level facts (no per-user fields, ever)
+# --------------------------------------------------------------------------- #
+
+
+class AudioFeatures(BaseModel):
+    """Scalar audio descriptors (AcousticBrainz / future enrichers). All
+    nullable — a track may be only partially enriched."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    bpm: float | None = None
+    energy: float | None = None
+    valence: float | None = None
+    danceability: float | None = None
+    acousticness: float | None = None
+    instrumentalness: float | None = None
+    source: str | None = None
+
+
+class TrackTag(BaseModel):
+    """One scene/cultural tag for a track (Last.fm and similar)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    tag: str
+    weight: float | None = None
+    source: str | None = None
+
+
+class TrackMetadataRecord(BaseModel):
+    """A track's anonymous facts as mirrored from the shared store.
+
+    Carries NO per-user data by construction (``extra="forbid"`` blocks any
+    stray ``user_id``/``played_at`` from leaking in). ``fetched_at`` is the TTL
+    anchor — tz-aware UTC; naive datetimes are treated as UTC by :func:`is_stale`.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    track_id: str
+    spotify_id: str | None = None
+    isrc: str | None = None
+    mbid: str | None = None
+    name: str
+    artist: str
+    audio_features: AudioFeatures | None = None
+    tags: list[TrackTag] = Field(default_factory=list)
+    fetched_at: datetime
+
+
+def is_stale(
+    record: TrackMetadataRecord,
+    *,
+    now: datetime,
+    ttl_days: int = DEFAULT_TTL_DAYS,
+) -> bool:
+    """True when ``record`` is older than the TTL and should be re-fetched."""
+    fetched = record.fetched_at
+    if fetched.tzinfo is None:
+        fetched = fetched.replace(tzinfo=UTC)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=UTC)
+    return (now - fetched) > timedelta(days=ttl_days)
+
+
+# --------------------------------------------------------------------------- #
+# SharedStore — protocol + implementations
+# --------------------------------------------------------------------------- #
+
+
+@runtime_checkable
+class SharedStore(Protocol):
+    """Bulk-read / bulk-write interface to the shared metadata store.
+
+    Only bulk operations exist on purpose: there is no ``get_track`` singular,
+    so the pull-and-cache no-round-trip rule is enforced by the type, not by
+    convention.
+    """
+
+    def get_tracks(self, track_ids: Sequence[str]) -> dict[str, TrackMetadataRecord]:
+        """Return the records that exist for ``track_ids`` (missing ids omitted)."""
+        ...
+
+    def upsert_tracks(self, records: Sequence[TrackMetadataRecord]) -> None:
+        """Insert-or-replace ``records`` by ``track_id`` (enricher write-back)."""
+        ...
+
+
+class InMemorySharedStore:
+    """Dict-backed :class:`SharedStore` — the real store in tests and the
+    offline fallback. ``get_calls`` records each bulk read so tests can assert
+    the no-round-trip invariant."""
+
+    def __init__(self, records: Sequence[TrackMetadataRecord] | None = None) -> None:
+        self._rows: dict[str, TrackMetadataRecord] = {}
+        self.get_calls: list[list[str]] = []
+        if records:
+            self.upsert_tracks(records)
+
+    def get_tracks(self, track_ids: Sequence[str]) -> dict[str, TrackMetadataRecord]:
+        ids = list(track_ids)
+        self.get_calls.append(ids)
+        return {tid: self._rows[tid].model_copy(deep=True) for tid in ids if tid in self._rows}
+
+    def upsert_tracks(self, records: Sequence[TrackMetadataRecord]) -> None:
+        for record in records:
+            self._rows[record.track_id] = record.model_copy(deep=True)
+
+
+class SupabaseSharedStore:  # pragma: no cover - network-only, never run in CI
+    """Production :class:`SharedStore` over Supabase Postgres.
+
+    Network-only: the ``supabase`` SDK is imported lazily (optional extra
+    ``music-intel-mcp[supabase]``) and the client is built from ``SUPABASE_URL``
+    / ``SUPABASE_KEY``. Never exercised in CI — tests use
+    :class:`InMemorySharedStore`. Reads/writes the ``tracks`` + ``audio_features``
+    + ``tags`` tables (see ``supabase/migrations``).
+    """
+
+    def __init__(self, client: object | None = None) -> None:
+        self._client = client
+
+    @property
+    def client(self) -> object:
+        if self._client is None:
+            try:
+                from supabase import create_client
+            except ImportError as exc:
+                raise RuntimeError(
+                    "SupabaseSharedStore needs the 'supabase' extra: "
+                    "pip install 'music-intel-mcp[supabase]'"
+                ) from exc
+            url = os.environ.get(_SUPABASE_URL_ENV)
+            key = os.environ.get(_SUPABASE_KEY_ENV)
+            if not url or not key:
+                raise RuntimeError(
+                    f"{_SUPABASE_URL_ENV}/{_SUPABASE_KEY_ENV} must be set "
+                    "to use the live shared store."
+                )
+            self._client = create_client(url, key)
+        return self._client
+
+    def get_tracks(self, track_ids: Sequence[str]) -> dict[str, TrackMetadataRecord]:
+        ids = list(track_ids)
+        if not ids:
+            return {}
+        client = self.client
+        tracks = client.table("tracks").select("*").in_("id", ids).execute().data
+        feats = client.table("audio_features").select("*").in_("track_id", ids).execute().data
+        tags = client.table("tags").select("*").in_("track_id", ids).execute().data
+
+        feat_by_id = {f["track_id"]: f for f in feats}
+        tags_by_id: dict[str, list[dict]] = {}
+        for row in tags:
+            tags_by_id.setdefault(row["track_id"], []).append(row)
+
+        out: dict[str, TrackMetadataRecord] = {}
+        for row in tracks:
+            tid = row["id"]
+            feat = feat_by_id.get(tid)
+            out[tid] = TrackMetadataRecord(
+                track_id=tid,
+                spotify_id=row.get("spotify_id"),
+                isrc=row.get("isrc"),
+                mbid=row.get("mbid"),
+                name=row["name"],
+                artist=row["artist"],
+                audio_features=AudioFeatures(**_audio_cols(feat)) if feat else None,
+                tags=[
+                    TrackTag(tag=t["tag"], weight=t.get("weight"), source=t.get("source"))
+                    for t in tags_by_id.get(tid, [])
+                ],
+                fetched_at=row["fetched_at"],
+            )
+        return out
+
+    def upsert_tracks(self, records: Sequence[TrackMetadataRecord]) -> None:
+        if not records:
+            return
+        client = self.client
+        client.table("tracks").upsert(
+            [
+                {
+                    "id": r.track_id,
+                    "spotify_id": r.spotify_id,
+                    "isrc": r.isrc,
+                    "mbid": r.mbid,
+                    "name": r.name,
+                    "artist": r.artist,
+                    "fetched_at": r.fetched_at.isoformat(),
+                }
+                for r in records
+            ]
+        ).execute()
+        feat_rows = [
+            {"track_id": r.track_id, **_audio_cols(r.audio_features.model_dump())}
+            for r in records
+            if r.audio_features is not None
+        ]
+        if feat_rows:
+            client.table("audio_features").upsert(feat_rows).execute()
+        tag_rows = [
+            {"track_id": r.track_id, "tag": t.tag, "weight": t.weight, "source": t.source}
+            for r in records
+            for t in r.tags
+        ]
+        if tag_rows:
+            client.table("tags").upsert(tag_rows, on_conflict="track_id,tag,source").execute()
+
+
+def _audio_cols(data: dict) -> dict:  # pragma: no cover - used only by Supabase path
+    cols = (
+        "bpm",
+        "energy",
+        "valence",
+        "danceability",
+        "acousticness",
+        "instrumentalness",
+        "source",
+    )
+    return {c: data.get(c) for c in cols}
+
+
+# --------------------------------------------------------------------------- #
+# Local metadata cache (materialised pull target)
+# --------------------------------------------------------------------------- #
+
+
+class MetadataCache:
+    """Local materialisation of pulled shared-store records.
+
+    Lives under ``<data root>/cache/<track_id>.json``. Regenerable and
+    gitignored; filenames are percent-encoded so any canonical id (including the
+    ``name:<n>\\x1f<a>`` fallback) round-trips collision-free.
+    """
+
+    def __init__(self, root: str | Path | None = None) -> None:
+        self.root = resolve_data_root(root)
+
+    @property
+    def cache_dir(self) -> Path:
+        return self.root / "cache"
+
+    def _path(self, track_id: str) -> Path:
+        return self.cache_dir / f"{quote(track_id, safe='')}.json"
+
+    def read(self, track_id: str) -> TrackMetadataRecord | None:
+        path = self._path(track_id)
+        if not path.exists():
+            return None
+        return TrackMetadataRecord.model_validate_json(path.read_text(encoding="utf-8"))
+
+    def read_many(self, track_ids: Sequence[str]) -> dict[str, TrackMetadataRecord]:
+        out: dict[str, TrackMetadataRecord] = {}
+        for tid in track_ids:
+            record = self.read(tid)
+            if record is not None:
+                out[tid] = record
+        return out
+
+    def write(self, record: TrackMetadataRecord) -> Path:
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        path = self._path(record.track_id)
+        path.write_text(record.model_dump_json(indent=2), encoding="utf-8")
+        return path
+
+    def write_many(self, records: Sequence[TrackMetadataRecord]) -> None:
+        for record in records:
+            self.write(record)
+
+
+# --------------------------------------------------------------------------- #
+# Pull-and-cache orchestrator
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class PullResult:
+    """Outcome of a :func:`pull_and_cache` run.
+
+    - ``records`` — all metadata available for analysis (fresh cache hits +
+      freshly pulled + stale-but-present, keyed by ``track_id``).
+    - ``cache_hits`` — served from the local cache without touching the store.
+    - ``pulled`` — fresh records pulled from the shared store this run.
+    - ``stale`` — present in the store but past TTL; surfaced for re-enrichment.
+    - ``missing`` — no metadata anywhere; the enricher must derive these.
+    """
+
+    records: dict[str, TrackMetadataRecord]
+    cache_hits: list[str] = field(default_factory=list)
+    pulled: list[str] = field(default_factory=list)
+    stale: list[str] = field(default_factory=list)
+    missing: list[str] = field(default_factory=list)
+
+
+def pull_and_cache(
+    track_ids: Sequence[str],
+    store: SharedStore,
+    cache: MetadataCache,
+    *,
+    now: datetime,
+    ttl_days: int = DEFAULT_TTL_DAYS,
+) -> PullResult:
+    """Materialise metadata for ``track_ids`` into the local cache, offline-first.
+
+    Fresh cache entries are served without touching ``store``. Everything else
+    (uncached or stale) is collected and fetched in a **single** bulk
+    :meth:`SharedStore.get_tracks` call — the no-round-trip invariant. Freshly
+    pulled records are written back to the cache.
+    """
+    unique_ids = list(dict.fromkeys(track_ids))
+    result = PullResult(records={})
+
+    cached = cache.read_many(unique_ids)
+    to_pull: list[str] = []
+    for tid in unique_ids:
+        record = cached.get(tid)
+        if record is not None and not is_stale(record, now=now, ttl_days=ttl_days):
+            result.records[tid] = record
+            result.cache_hits.append(tid)
+        else:
+            to_pull.append(tid)
+
+    if to_pull:
+        fetched = store.get_tracks(to_pull)
+        to_write: list[TrackMetadataRecord] = []
+        for tid in to_pull:
+            record = fetched.get(tid)
+            if record is None:
+                result.missing.append(tid)
+                continue
+            result.records[tid] = record
+            to_write.append(record)
+            if is_stale(record, now=now, ttl_days=ttl_days):
+                result.stale.append(tid)
+            else:
+                result.pulled.append(tid)
+        cache.write_many(to_write)
+
+    return result

--- a/src/music_intel_mcp/store.py
+++ b/src/music_intel_mcp/store.py
@@ -24,7 +24,9 @@ _DATA_DIR_ENV = "MUSIC_INTEL_DATA_DIR"
 _UNSAFE_FILENAME = re.compile(r"[^A-Za-z0-9._-]+")
 
 
-def _resolve_root(root: str | Path | None) -> Path:
+def resolve_data_root(root: str | Path | None) -> Path:
+    """Resolve the data root: explicit arg > ``MUSIC_INTEL_DATA_DIR`` > default.
+    Shared by the per-user store and the (local) shared-metadata cache."""
     if root is not None:
         return Path(root)
     return Path(os.environ.get(_DATA_DIR_ENV, DEFAULT_DATA_DIR))
@@ -34,7 +36,7 @@ class UserStore:
     """Read history, read/write RootProfile snapshots for one user."""
 
     def __init__(self, root: str | Path | None = None) -> None:
-        self.root = _resolve_root(root)
+        self.root = resolve_data_root(root)
 
     @property
     def history_path(self) -> Path:

--- a/supabase/migrations/20260609000000_shared_metadata.sql
+++ b/supabase/migrations/20260609000000_shared_metadata.sql
@@ -1,0 +1,65 @@
+-- Shared metadata store — V0 schema (issue #60, decision f7a9fcbd).
+--
+-- Anonymous, multi-user-ready track-level facts. There are NO per-user columns
+-- anywhere in this schema by design (no user_id, no played_at, no play-context):
+-- listening history and RootProfile snapshots never leave the user's machine.
+-- Every fact row carries fetched_at as its ~90-day TTL anchor.
+
+-- Artist-level facts. Defined for the identity waterfall (#61) and future
+-- artist enrichment; the V0 TrackMetadataRecord denormalises name onto tracks.
+create table if not exists artists (
+    id          uuid primary key default gen_random_uuid(),
+    mbid        text unique,
+    name        text not null,
+    created_at  timestamptz not null default now(),
+    updated_at  timestamptz not null default now()
+);
+
+-- Canonical track identity + denormalised display facts. The primary key is our
+-- canonical string id (mbid:… / isrc:… / spotify:… / name:…); see
+-- shared_store.canonical_track_id.
+create table if not exists tracks (
+    id          text primary key,
+    spotify_id  text,
+    isrc        text,
+    mbid        text,
+    name        text not null,
+    artist      text not null,
+    artist_id   uuid references artists (id) on delete set null,
+    fetched_at  timestamptz not null default now(),
+    created_at  timestamptz not null default now(),
+    updated_at  timestamptz not null default now()
+);
+
+-- Identity-waterfall lookup indexes (#61).
+create index if not exists tracks_spotify_id_idx on tracks (spotify_id);
+create index if not exists tracks_isrc_idx on tracks (isrc);
+create index if not exists tracks_mbid_idx on tracks (mbid);
+
+-- Scalar audio descriptors (AcousticBrainz / future enrichers). One row per
+-- track; all features nullable (a track may be only partially enriched).
+create table if not exists audio_features (
+    track_id        text primary key references tracks (id) on delete cascade,
+    bpm             real,
+    energy          real,
+    valence         real,
+    danceability    real,
+    acousticness    real,
+    instrumentalness real,
+    source          text,
+    fetched_at      timestamptz not null default now(),
+    updated_at      timestamptz not null default now()
+);
+
+-- Scene/cultural tags (Last.fm and similar). Many rows per track.
+create table if not exists tags (
+    id          bigint generated always as identity primary key,
+    track_id    text not null references tracks (id) on delete cascade,
+    tag         text not null,
+    weight      real,
+    source      text,
+    fetched_at  timestamptz not null default now(),
+    unique (track_id, tag, source)
+);
+
+create index if not exists tags_track_id_idx on tags (track_id);

--- a/tests/test_shared_store.py
+++ b/tests/test_shared_store.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 
 import pytest
+from pydantic import ValidationError
+
 from music_intel_mcp.models import TrackRef
 from music_intel_mcp.shared_store import (
     AudioFeatures,
@@ -19,7 +21,6 @@ from music_intel_mcp.shared_store import (
     is_stale,
     pull_and_cache,
 )
-from pydantic import ValidationError
 
 T0 = datetime(2026, 1, 1, tzinfo=UTC)
 

--- a/tests/test_shared_store.py
+++ b/tests/test_shared_store.py
@@ -1,0 +1,201 @@
+"""Shared metadata store + pull-and-cache (#60).
+
+No live Supabase, no network — the in-memory store is the real store here.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from music_intel_mcp.models import TrackRef
+from music_intel_mcp.shared_store import (
+    AudioFeatures,
+    InMemorySharedStore,
+    MetadataCache,
+    TrackMetadataRecord,
+    TrackTag,
+    canonical_track_id,
+    is_stale,
+    pull_and_cache,
+)
+from pydantic import ValidationError
+
+T0 = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _record(track_id: str, *, fetched_at: datetime = T0, name: str = "Song") -> TrackMetadataRecord:
+    return TrackMetadataRecord(
+        track_id=track_id,
+        name=name,
+        artist="Artist",
+        audio_features=AudioFeatures(bpm=120.0, energy=0.8, source="acousticbrainz"),
+        tags=[TrackTag(tag="dream pop", weight=0.9, source="lastfm")],
+        fetched_at=fetched_at,
+    )
+
+
+# --- identity -------------------------------------------------------------- #
+
+
+def test_canonical_track_id_waterfall():
+    assert canonical_track_id(TrackRef(name="n", artist="a", mbid="M", isrc="I")) == "mbid:M"
+    assert canonical_track_id(TrackRef(name="n", artist="a", isrc="I", spotify_id="S")) == "isrc:I"
+    assert canonical_track_id(TrackRef(name="n", artist="a", spotify_id="S")) == "spotify:S"
+    # fallback is case-folded name + artist
+    assert canonical_track_id(TrackRef(name="Né", artist="A")) == "name:né\x1fa"
+
+
+# --- record contract: no per-user data ------------------------------------- #
+
+
+def test_record_rejects_personal_fields():
+    """The shared store holds anonymous facts only — a stray per-user field
+    must be refused (extra='forbid')."""
+    with pytest.raises(ValidationError):
+        TrackMetadataRecord(
+            track_id="spotify:X",
+            name="n",
+            artist="a",
+            fetched_at=T0,
+            user_id="petr",  # personal data has no place in the shared store
+        )
+
+
+# --- TTL ------------------------------------------------------------------- #
+
+
+def test_is_stale_ttl_boundary():
+    rec = _record("spotify:X", fetched_at=T0)
+    assert not is_stale(rec, now=T0 + timedelta(days=90), ttl_days=90)
+    assert is_stale(rec, now=T0 + timedelta(days=91), ttl_days=90)
+
+
+def test_is_stale_treats_naive_as_utc():
+    rec = _record("spotify:X", fetched_at=datetime(2026, 1, 1))  # naive
+    assert not is_stale(rec, now=datetime(2026, 1, 2))  # naive now, both UTC
+
+
+# --- InMemorySharedStore --------------------------------------------------- #
+
+
+def test_in_memory_store_roundtrip_and_spy():
+    store = InMemorySharedStore([_record("spotify:A"), _record("spotify:B")])
+    got = store.get_tracks(["spotify:A", "spotify:MISSING"])
+    assert set(got) == {"spotify:A"}
+    assert store.get_calls == [["spotify:A", "spotify:MISSING"]]
+    # returned copies are isolated from the store's internal rows
+    got["spotify:A"].name = "mutated"
+    assert store.get_tracks(["spotify:A"])["spotify:A"].name == "Song"
+
+
+# --- MetadataCache --------------------------------------------------------- #
+
+
+def test_cache_roundtrip(tmp_path):
+    cache = MetadataCache(root=tmp_path)
+    rec = _record("spotify:A")
+    cache.write(rec)
+    assert cache.read("spotify:A") == rec
+    assert cache.read("spotify:MISSING") is None
+
+
+def test_cache_filename_safe_for_fallback_id(tmp_path):
+    """The name/artist fallback id contains '\\x1f' and spaces; the filename
+    must be filesystem-safe and round-trip."""
+    cache = MetadataCache(root=tmp_path)
+    tid = "name:some song\x1fsome artist"
+    cache.write(_record(tid))
+    [path] = list(cache.cache_dir.glob("*.json"))
+    assert "/" not in path.name and "\x1f" not in path.name and " " not in path.name
+    assert cache.read(tid).track_id == tid
+
+
+# --- pull_and_cache -------------------------------------------------------- #
+
+
+def test_pull_cold_writes_cache_and_returns_pulled(tmp_path):
+    store = InMemorySharedStore([_record("spotify:A"), _record("spotify:B")])
+    cache = MetadataCache(root=tmp_path)
+
+    result = pull_and_cache(["spotify:A", "spotify:B"], store, cache, now=T0)
+
+    assert set(result.records) == {"spotify:A", "spotify:B"}
+    assert sorted(result.pulled) == ["spotify:A", "spotify:B"]
+    assert result.cache_hits == []
+    # materialised locally
+    assert cache.read("spotify:A") is not None
+    assert cache.read("spotify:B") is not None
+
+
+def test_pull_warm_cache_does_not_touch_store(tmp_path):
+    """Second pull is served entirely from the local cache — the no-round-trip
+    invariant: the store is not queried at all."""
+    store = InMemorySharedStore([_record("spotify:A")])
+    cache = MetadataCache(root=tmp_path)
+
+    pull_and_cache(["spotify:A"], store, cache, now=T0)
+    assert len(store.get_calls) == 1
+
+    result = pull_and_cache(["spotify:A"], store, cache, now=T0 + timedelta(days=1))
+    assert result.cache_hits == ["spotify:A"]
+    assert result.pulled == []
+    assert len(store.get_calls) == 1  # store NOT queried the second time
+
+
+def test_pull_single_bulk_query_for_mixed_batch(tmp_path):
+    """A batch of N uncached tracks triggers exactly one bulk get_tracks call,
+    not N per-track round-trips."""
+    store = InMemorySharedStore([_record(f"spotify:{i}") for i in range(5)])
+    cache = MetadataCache(root=tmp_path)
+
+    pull_and_cache([f"spotify:{i}" for i in range(5)], store, cache, now=T0)
+
+    assert len(store.get_calls) == 1
+    assert len(store.get_calls[0]) == 5
+
+
+def test_pull_stale_cache_triggers_refetch(tmp_path):
+    store = InMemorySharedStore([_record("spotify:A", fetched_at=T0)])
+    cache = MetadataCache(root=tmp_path)
+
+    # initial pull at T0 caches the T0 record
+    pull_and_cache(["spotify:A"], store, cache, now=T0)
+    assert len(store.get_calls) == 1
+
+    # enricher refreshes the shared store with a newer record
+    fresh = _record("spotify:A", fetched_at=T0 + timedelta(days=100), name="Refreshed")
+    store.upsert_tracks([fresh])
+
+    # 100 days later the cached entry is stale -> re-fetch from the store
+    later = T0 + timedelta(days=100)
+    result = pull_and_cache(["spotify:A"], store, cache, now=later)
+
+    assert len(store.get_calls) == 2  # re-fetch path taken
+    assert result.pulled == ["spotify:A"]
+    assert result.records["spotify:A"].name == "Refreshed"
+    assert cache.read("spotify:A").name == "Refreshed"  # cache rewritten
+
+
+def test_pull_missing_track_surfaced(tmp_path):
+    store = InMemorySharedStore([_record("spotify:A")])
+    cache = MetadataCache(root=tmp_path)
+
+    result = pull_and_cache(["spotify:A", "spotify:GHOST"], store, cache, now=T0)
+
+    assert result.pulled == ["spotify:A"]
+    assert result.missing == ["spotify:GHOST"]
+    assert "spotify:GHOST" not in result.records
+
+
+def test_pull_store_entry_past_ttl_flagged_stale(tmp_path):
+    """A store record that is itself past TTL is materialised but flagged for
+    re-enrichment, not treated as fresh."""
+    store = InMemorySharedStore([_record("spotify:A", fetched_at=T0)])
+    cache = MetadataCache(root=tmp_path)
+
+    result = pull_and_cache(["spotify:A"], store, cache, now=T0 + timedelta(days=200))
+
+    assert result.stale == ["spotify:A"]
+    assert result.pulled == []
+    assert "spotify:A" in result.records  # still usable for partial analysis


### PR DESCRIPTION
## Slice #60 — shared metadata store + pull-and-cache

Stands up the **shared metadata store** (anonymous track-level facts, Supabase Postgres) and the **pull-and-cache** access pattern every enricher/analyser step uses. Decision `f7a9fcbd`.

Closes #60.

### What landed

- **`shared_store.py`** — the store layer every enricher (#61/#63/#64) writes to and the analyser reads:
  - **`TrackMetadataRecord`** (the pull unit) — a track's `tracks` row + `audio_features` + `tags` + `fetched_at`. `extra="forbid"` is the structural guard that **no per-user field can leak into a shared-store record**.
  - **`SharedStore`** protocol — **bulk-only** (`get_tracks` / `upsert_tracks`, no singular getter), so the no-round-trip rule is enforced by the type, not by convention. `InMemorySharedStore` is the real store in tests + offline fallback; `SupabaseSharedStore` is network-only (lazy `supabase` extra, never run in CI).
  - **`MetadataCache`** — local materialisation under `data/cache/<track_id>.json`; percent-encoded filenames round-trip any canonical id collision-free.
  - **`pull_and_cache(ids, store, cache, now, ttl_days=90)`** — fresh cache entries served offline; uncached/stale ids fetched in **one** bulk call; stale (past-TTL) store entries surfaced for re-enrichment, missing ids for enrichment.
  - **`canonical_track_id`** — string form of the `mbid > isrc > spotify > name/artist` waterfall (#61 unifies this with the analyser's tuple key).
- **`supabase/migrations/20260609000000_shared_metadata.sql`** — DDL for `tracks` / `artists` / `audio_features` / `tags`. **No per-user columns anywhere** (no `user_id`, no `played_at`).
- **`pyproject.toml`** — `supabase` as an **optional extra** (CI uses the in-memory store; light default install).
- Shared-store schema documented in `CONTEXT.md`.

### Acceptance criteria

- [x] Migration creates the shared-store tables; schema documented in CONTEXT.md
- [x] Enriching a fixture track set writes rows to the store and they pull down into the local cache (`test_pull_cold_writes_cache_and_returns_pulled`)
- [x] 90-day TTL honored — stale entry triggers re-fetch path (`test_pull_stale_cache_triggers_refetch`, `test_is_stale_ttl_boundary`)
- [x] CI uses mocks/fixtures — no live Supabase or API calls (in-memory store throughout; supabase is an unused optional extra)
- [x] Personal data never written to the shared store (`extra="forbid"` on the record + `test_record_rejects_personal_fields`; no per-user column in the DDL)

Also covered: no-round-trip invariant (`test_pull_warm_cache_does_not_touch_store`, `test_pull_single_bulk_query_for_mixed_batch`).

13 new tests, full suite (33) green, ruff lint + format + pre-commit clean. No live API calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
