### PR TITLE
feat: validation / classification core — 3-class + 4 V0 tests (#62)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -87,6 +87,22 @@ Waterfall, deepest rung wins: **`mbid`** (already present, passthrough) → **`i
 
 The same `canonical_track_id()` waterfall (mbid > isrc > spotify > name/artist) is the single source of truth for track keys — the analyser's unique-track counting now calls it directly (the old `analyzer._track_key` tuple was folded into it).
 
+## Validation / classification (V0)
+
+The **validation core** is the category-agnostic deep module every derivation pipeline feeds candidates into. Python: `src/music_intel_mcp/validation.py`. Issue #62, decision `bce66b6e`. It is the *only* place the three-class verdict lives — audio/scene/temporal (#63–#65) build `Candidate`s and hand them here; they do not classify themselves.
+
+- **`Candidate`** — a category-neutral summary of one derived pattern: `candidate_id`, `category`, `cluster_size`, `cluster_share`, `evidence_count`, `coverage`, `confidence`, optional `temporal_stability_score`, plus the pass-through `structural_descriptor` / `sample_tracks` / `actionability_hint`. The validator reads only the scalars; the descriptor rides through onto the resulting root/tendency.
+- **`DatasetContext`** — `n_unique_tracks` + `history_span_days`, the dataset-wide facts the temporal gate depends on. Passed once per run (constant across candidates), not per candidate.
+- **`Validator(params=ValidationParams())`** — `classify(candidate, ctx) -> Classified` (one verdict) and `validate(candidates, ctx) -> ValidationOutcome` (batch → the three RootProfile sections `roots[]` / `tendencies[]` / `quality_log[]`, input order preserved).
+
+The four V0 tests and their order:
+
+1. **G — calibration** (`evidence_count >= evidence_count_floor`, default 50) and **E — coverage floor** (`coverage >= coverage_floors["tendency"]`, default 0.3) are the **hard floors**: failing either → `artifact_suspect`, suppressed from the user-facing sections and logged to `quality_log[]` (G checked first — no evidence is a more fundamental failure than thin coverage; details match the schema example: `{evidence_count, floor}` resp. `{coverage, floor_artifact}`).
+2. Survivors are at least a `tendency`. **E (root floor)** `coverage >= coverage_floors["root"]` (0.5) sets `coverage_pass`; **A — confidence floor** `confidence >= confidence_floor` (0.6) sets `confidence_pass`; **D — temporal stability** is evaluated **only** when the gate is open (`n_unique_tracks > N_THRESHOLD` AND `history_span_days > T_THRESHOLD_DAYS`) *and* the candidate carries a score — then it must clear `temporal_stability_floor` (new param, default 0.5, `(calibrate)`). Otherwise it is `not_evaluated` and the candidate is forced to `tendency` (we never assert stability we could not measure).
+3. A candidate that fails **no** promotion test is a `root`; otherwise a `tendency` carrying `failed_tests[]` — `"coverage_floor"`, `"confidence_floor"`, `"temporal_stability"` (evaluated-but-low), or `"temporal_stability_not_evaluated"` (gate closed / no score). Failed tests accumulate.
+
+Every threshold is read from `method_params.validation` (`ValidationParams`) — none hardcoded; they are placeholders until calibrated on the owner's real data in #66. Honest-empty holds structurally: zero passing candidates → empty `roots[]` with a populated `quality_log[]`.
+
 ## Invariants
 
 - **Transparency.** Every insight, score, and recommendation carries its evidence chain. No opaque numbers. If we can't explain it, we don't ship it.

--- a/schemas/root_profile.v0.example.json
+++ b/schemas/root_profile.v0.example.json
@@ -63,6 +63,7 @@
       "N_THRESHOLD": 1000,
       "T_THRESHOLD_DAYS": 180,
       "confidence_floor": 0.6,
+      "temporal_stability_floor": 0.5,
       "evidence_count_floor": 50,
       "coverage_floors": {"root": 0.5, "tendency": 0.3, "artifact_suspect": 0.0}
     }

--- a/src/music_intel_mcp/models.py
+++ b/src/music_intel_mcp/models.py
@@ -74,6 +74,7 @@ class ValidationParams(BaseModel):
     N_THRESHOLD: int = 1000
     T_THRESHOLD_DAYS: int = 180
     confidence_floor: float = 0.6
+    temporal_stability_floor: float = 0.5
     evidence_count_floor: int = 50
     coverage_floors: dict[str, float] = Field(
         default_factory=lambda: {"root": 0.5, "tendency": 0.3, "artifact_suspect": 0.0}

--- a/src/music_intel_mcp/validation.py
+++ b/src/music_intel_mcp/validation.py
@@ -1,0 +1,246 @@
+"""Validation / classification core (#62).
+
+The category-agnostic deep module every derivation pipeline feeds candidates
+into. A *candidate* is a category-neutral summary of a derived pattern
+(cluster size, coverage, confidence, a chronological-split stability score);
+this module classifies each into exactly one of three buckets per decision
+``bce66b6e``:
+
+- **``root``** — clears every V0 test; the confident, stable, well-covered
+  patterns the artifact is built around.
+- **``tendency``** — a *real* pattern (enough evidence and coverage to not be
+  noise) that fell short on at least one promotion test (confidence floor,
+  coverage→root floor, or temporal stability). Surfaced separately, labelled
+  with the tests it failed — never called a root.
+- **``artifact_suspect``** — fails a hard floor (too little evidence, or
+  coverage below the floor that distinguishes signal from noise). Suppressed
+  from the user-facing sections but recorded in ``quality_log[]`` with the
+  failed test and details. **Transparent rejection** — nothing is silently
+  dropped.
+
+The four V0 tests (decision ``bce66b6e``):
+
+- **A — confidence floor.** ``confidence >= confidence_floor`` to be a root.
+- **D — temporal stability (gated).** Evaluated only when the dataset is large
+  and long enough (``n_unique_tracks > N_THRESHOLD`` AND
+  ``history_span_days > T_THRESHOLD_DAYS``) *and* the candidate carries a split
+  score. Otherwise ``not_evaluated`` and the candidate is forced to
+  ``tendency`` — we never assert stability we could not measure.
+- **E — coverage labelling.** Below the tendency floor → ``artifact_suspect``;
+  between the tendency and root floors → capped at ``tendency``; at/above the
+  root floor → eligible for ``root``.
+- **G — calibration.** ``evidence_count >= evidence_count_floor`` — clusters
+  too small to be statistically meaningful are artifacts.
+
+Every threshold is read from :class:`ValidationParams` (``method_params``),
+never hardcoded — they are placeholders until calibrated on real data in #66.
+The module is verified against synthetic candidates; the audio/scene/temporal
+pipelines (#63–#65) construct real :class:`Candidate`s and hand them here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from .models import (
+    Evidence,
+    QualityLogEntry,
+    Root,
+    TemporalStability,
+    Tendency,
+    ValidationParams,
+    ValidationScores,
+)
+
+Verdict = Literal["root", "tendency", "artifact_suspect"]
+
+
+# --------------------------------------------------------------------------- #
+# Inputs
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """A category-neutral summary of one derived pattern. The derivation
+    pipelines fill ``structural_descriptor`` (category-specific) and the
+    evidence scalars; the validator reads only the scalars to classify, and
+    passes the descriptor + samples through onto the resulting root/tendency."""
+
+    candidate_id: str
+    category: str
+    cluster_size: int
+    cluster_share: float
+    evidence_count: int
+    coverage: float
+    confidence: float
+    structural_descriptor: dict[str, Any]
+    temporal_stability_score: float | None = None
+    sample_tracks: list[dict[str, Any]] = field(default_factory=list)
+    actionability_hint: str | None = None
+
+
+@dataclass(frozen=True)
+class DatasetContext:
+    """Dataset-wide facts the temporal-stability gate (test D) depends on.
+    Constant across a run, so it is passed once to :meth:`Validator.validate`
+    rather than carried per candidate."""
+
+    n_unique_tracks: int
+    history_span_days: int
+
+
+# --------------------------------------------------------------------------- #
+# Outputs
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class Classified:
+    """The verdict for one candidate. Exactly one of ``item`` (root/tendency)
+    or ``rejected`` (artifact_suspect) is populated."""
+
+    verdict: Verdict
+    item: Root | Tendency | None = None
+    rejected: QualityLogEntry | None = None
+
+
+@dataclass
+class ValidationOutcome:
+    """The three RootProfile sections this module owns, ready to drop straight
+    into a :class:`~music_intel_mcp.models.RootProfile`."""
+
+    roots: list[Root] = field(default_factory=list)
+    tendencies: list[Tendency] = field(default_factory=list)
+    quality_log: list[QualityLogEntry] = field(default_factory=list)
+
+
+# --------------------------------------------------------------------------- #
+# Validator
+# --------------------------------------------------------------------------- #
+
+
+class Validator:
+    """Classifies candidates into root / tendency / artifact_suspect using the
+    thresholds in :class:`ValidationParams`."""
+
+    def __init__(self, params: ValidationParams | None = None) -> None:
+        self.params = params or ValidationParams()
+
+    def _gate_open(self, ctx: DatasetContext) -> bool:
+        """Test D gate: enough unique tracks AND long enough span to trust a
+        chronological-split stability measurement."""
+        p = self.params
+        return ctx.n_unique_tracks > p.N_THRESHOLD and ctx.history_span_days > p.T_THRESHOLD_DAYS
+
+    def classify(self, cand: Candidate, ctx: DatasetContext) -> Classified:
+        p = self.params
+        tendency_floor = p.coverage_floors["tendency"]
+        root_floor = p.coverage_floors["root"]
+
+        # --- Hard floors → artifact_suspect (suppressed, logged). G before E:
+        #     no evidence is a more fundamental failure than thin coverage. ---
+        if cand.evidence_count < p.evidence_count_floor:
+            return self._reject(
+                cand,
+                "calibration",
+                {"evidence_count": cand.evidence_count, "floor": p.evidence_count_floor},
+            )
+        if cand.coverage < tendency_floor:
+            return self._reject(
+                cand,
+                "coverage_floor",
+                {"coverage": cand.coverage, "floor_artifact": tendency_floor},
+            )
+
+        # --- Survivors are at least a tendency. Run the promotion tests. ---
+        failed: list[str] = []
+
+        coverage_pass = cand.coverage >= root_floor
+        if not coverage_pass:
+            failed.append("coverage_floor")
+
+        confidence_pass = cand.confidence >= p.confidence_floor
+        if not confidence_pass:
+            failed.append("confidence_floor")
+
+        # D — gated temporal stability. Evaluated only with an open gate AND a
+        # score; otherwise not_evaluated, which forbids promotion to root.
+        if self._gate_open(ctx) and cand.temporal_stability_score is not None:
+            stability = TemporalStability(status="evaluated", score=cand.temporal_stability_score)
+            if cand.temporal_stability_score < p.temporal_stability_floor:
+                failed.append("temporal_stability")
+        else:
+            stability = TemporalStability(status="not_evaluated", score=None)
+            failed.append("temporal_stability_not_evaluated")
+
+        scores = ValidationScores(
+            confidence=cand.confidence,
+            temporal_stability=stability,
+            coverage_pass=coverage_pass,
+            confidence_pass=confidence_pass,
+        )
+        evidence = Evidence(
+            cluster_size=cand.cluster_size,
+            cluster_share=cand.cluster_share,
+            evidence_count=cand.evidence_count,
+            sample_tracks=cand.sample_tracks,
+            coverage=cand.coverage,
+        )
+
+        if not failed:
+            return Classified(
+                verdict="root",
+                item=Root(
+                    id=cand.candidate_id,
+                    category=cand.category,
+                    classification="root",
+                    structural_descriptor=cand.structural_descriptor,
+                    evidence=evidence,
+                    validation_scores=scores,
+                    actionability_hint=cand.actionability_hint,
+                ),
+            )
+        return Classified(
+            verdict="tendency",
+            item=Tendency(
+                id=cand.candidate_id,
+                category=cand.category,
+                classification="tendency",
+                structural_descriptor=cand.structural_descriptor,
+                evidence=evidence,
+                validation_scores=scores,
+                actionability_hint=cand.actionability_hint,
+                failed_tests=failed,
+            ),
+        )
+
+    def _reject(self, cand: Candidate, failed_test: str, details: dict[str, Any]) -> Classified:
+        return Classified(
+            verdict="artifact_suspect",
+            rejected=QualityLogEntry(
+                candidate_id=cand.candidate_id,
+                category=cand.category,
+                failed_test=failed_test,
+                details=details,
+            ),
+        )
+
+    def validate(self, candidates: Sequence[Candidate], ctx: DatasetContext) -> ValidationOutcome:
+        """Classify a batch, binning into the three RootProfile sections.
+        Order within each section follows input order (stable, inspectable)."""
+        outcome = ValidationOutcome()
+        for cand in candidates:
+            result = self.classify(cand, ctx)
+            if result.verdict == "root":
+                assert result.item is not None
+                outcome.roots.append(result.item)
+            elif result.verdict == "tendency":
+                assert isinstance(result.item, Tendency)
+                outcome.tendencies.append(result.item)
+            else:
+                assert result.rejected is not None
+                outcome.quality_log.append(result.rejected)
+        return outcome

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,241 @@
+"""Validation / classification core (#62).
+
+The category-agnostic deep module: a candidate (cluster_size / coverage /
+confidence / temporal-split score) classifies into one of three —
+``root`` / ``tendency`` / ``artifact_suspect`` — per the four V0 tests
+(A confidence floor, D gated temporal stability, E coverage labelling,
+G calibration). Verified against *synthetic* candidates; no real category
+pipeline exists yet.
+"""
+
+from __future__ import annotations
+
+from music_intel_mcp.models import ValidationParams
+from music_intel_mcp.validation import Candidate, DatasetContext, Validator
+
+# A dataset large/long enough to open the temporal-stability gate (test D):
+#   n_unique_tracks > N_THRESHOLD (1000) AND history_span_days > T_THRESHOLD (180).
+FULL_CTX = DatasetContext(n_unique_tracks=2000, history_span_days=400)
+# Below either threshold -> gate closed -> temporal stability not_evaluated.
+SMALL_CTX = DatasetContext(n_unique_tracks=100, history_span_days=30)
+
+
+def candidate(**overrides) -> Candidate:
+    """A would-be ``root``: passes every default floor. Tests override the one
+    field under examination so the failing test is the only moving part."""
+    base = dict(
+        candidate_id="c-audio-1",
+        category="audio",
+        cluster_size=200,
+        cluster_share=0.3,
+        evidence_count=200,
+        coverage=0.8,
+        confidence=0.8,
+        temporal_stability_score=0.9,
+        structural_descriptor={"bpm_band": "high"},
+    )
+    base.update(overrides)
+    return Candidate(**base)
+
+
+# --------------------------------------------------------------------------- #
+# Happy path — a candidate that clears every test is a root
+# --------------------------------------------------------------------------- #
+
+
+def test_clean_candidate_classifies_as_root():
+    outcome = Validator().validate([candidate()], FULL_CTX)
+
+    assert len(outcome.roots) == 1
+    assert outcome.tendencies == []
+    assert outcome.quality_log == []
+
+    root = outcome.roots[0]
+    assert root.classification == "root"
+    assert root.category == "audio"
+    assert root.validation_scores.coverage_pass is True
+    assert root.validation_scores.confidence_pass is True
+    assert root.validation_scores.temporal_stability.status == "evaluated"
+    assert root.evidence.cluster_size == 200
+    assert root.structural_descriptor == {"bpm_band": "high"}
+
+
+# --------------------------------------------------------------------------- #
+# Test A — confidence floor
+# --------------------------------------------------------------------------- #
+
+
+def test_below_confidence_floor_is_tendency_not_root():
+    outcome = Validator().validate([candidate(confidence=0.4)], FULL_CTX)
+
+    assert outcome.roots == []
+    assert outcome.quality_log == []  # still a real pattern, not suppressed
+    assert len(outcome.tendencies) == 1
+
+    tend = outcome.tendencies[0]
+    assert tend.classification == "tendency"
+    assert "confidence_floor" in tend.failed_tests
+    assert tend.validation_scores.confidence_pass is False
+    assert tend.validation_scores.coverage_pass is True
+
+
+# --------------------------------------------------------------------------- #
+# Test D — temporal stability, gated by dataset size
+# --------------------------------------------------------------------------- #
+
+
+def test_temporal_stability_gated_off_forces_tendency():
+    # Same clean candidate, but the dataset is too small/short to evaluate
+    # stability -> not_evaluated -> forced to tendency (never a root).
+    outcome = Validator().validate([candidate()], SMALL_CTX)
+
+    assert outcome.roots == []
+    assert len(outcome.tendencies) == 1
+    tend = outcome.tendencies[0]
+    assert tend.validation_scores.temporal_stability.status == "not_evaluated"
+    assert tend.validation_scores.temporal_stability.score is None
+    assert "temporal_stability_not_evaluated" in tend.failed_tests
+    # coverage/confidence still genuinely passed — only stability is unproven
+    assert tend.validation_scores.coverage_pass is True
+    assert tend.validation_scores.confidence_pass is True
+
+
+def test_temporal_stability_evaluated_but_low_is_tendency():
+    outcome = Validator().validate([candidate(temporal_stability_score=0.2)], FULL_CTX)
+
+    assert outcome.roots == []
+    tend = outcome.tendencies[0]
+    assert tend.validation_scores.temporal_stability.status == "evaluated"
+    assert tend.validation_scores.temporal_stability.score == 0.2
+    assert tend.failed_tests == ["temporal_stability"]
+
+
+def test_temporal_stability_missing_score_under_open_gate_is_not_evaluated():
+    # Gate open but the pipeline produced no split score -> cannot evaluate.
+    outcome = Validator().validate([candidate(temporal_stability_score=None)], FULL_CTX)
+
+    tend = outcome.tendencies[0]
+    assert tend.validation_scores.temporal_stability.status == "not_evaluated"
+    assert "temporal_stability_not_evaluated" in tend.failed_tests
+
+
+# --------------------------------------------------------------------------- #
+# Test E — coverage labelling (root floor / tendency floor / artifact floor)
+# --------------------------------------------------------------------------- #
+
+
+def test_coverage_below_artifact_floor_is_suppressed_artifact_suspect():
+    # coverage 0.2 < tendency floor 0.3 -> too sparse to be a real pattern.
+    outcome = Validator().validate([candidate(coverage=0.2)], FULL_CTX)
+
+    assert outcome.roots == []
+    assert outcome.tendencies == []  # suppressed from the user-facing artifact
+    assert len(outcome.quality_log) == 1
+
+    entry = outcome.quality_log[0]
+    assert entry.candidate_id == "c-audio-1"
+    assert entry.category == "audio"
+    assert entry.failed_test == "coverage_floor"
+    assert entry.details["coverage"] == 0.2
+    assert entry.details["floor_artifact"] == 0.3
+
+
+def test_coverage_between_tendency_and_root_floor_caps_at_tendency():
+    # 0.3 <= coverage 0.4 < 0.5 -> real enough to surface, not enough for root.
+    outcome = Validator().validate([candidate(coverage=0.4)], FULL_CTX)
+
+    assert outcome.roots == []
+    tend = outcome.tendencies[0]
+    assert tend.validation_scores.coverage_pass is False
+    assert "coverage_floor" in tend.failed_tests
+
+
+# --------------------------------------------------------------------------- #
+# Test G — calibration (evidence-count floor)
+# --------------------------------------------------------------------------- #
+
+
+def test_below_evidence_count_floor_is_artifact_suspect():
+    # evidence_count 10 < floor 50 -> statistical artifact, suppressed + logged.
+    outcome = Validator().validate([candidate(evidence_count=10)], FULL_CTX)
+
+    assert outcome.roots == []
+    assert outcome.tendencies == []
+    assert len(outcome.quality_log) == 1
+    entry = outcome.quality_log[0]
+    assert entry.failed_test == "calibration"
+    assert entry.details["evidence_count"] == 10
+    assert entry.details["floor"] == 50
+
+
+def test_calibration_checked_before_coverage_when_both_fail():
+    # Fails both G (evidence) and E (coverage); calibration is the reported cause.
+    outcome = Validator().validate([candidate(evidence_count=5, coverage=0.1)], FULL_CTX)
+    assert outcome.quality_log[0].failed_test == "calibration"
+
+
+# --------------------------------------------------------------------------- #
+# Thresholds come from method_params, not hardcoded
+# --------------------------------------------------------------------------- #
+
+
+def test_thresholds_sourced_from_method_params():
+    # A candidate that is a root under defaults (confidence 0.8) becomes a
+    # tendency under a stricter custom confidence floor -> proves the floor is
+    # read from params, not baked in.
+    strict = ValidationParams(confidence_floor=0.9)
+    outcome = Validator(strict).validate([candidate(confidence=0.8)], FULL_CTX)
+
+    assert outcome.roots == []
+    assert "confidence_floor" in outcome.tendencies[0].failed_tests
+
+
+def test_custom_temporal_stability_floor_respected():
+    lenient = ValidationParams(temporal_stability_floor=0.1)
+    outcome = Validator(lenient).validate([candidate(temporal_stability_score=0.2)], FULL_CTX)
+    # 0.2 >= custom floor 0.1 -> stability passes -> root
+    assert len(outcome.roots) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Honest-empty + transparent rejection over a batch
+# --------------------------------------------------------------------------- #
+
+
+def test_zero_candidates_is_honest_empty():
+    outcome = Validator().validate([], FULL_CTX)
+    assert outcome.roots == []
+    assert outcome.tendencies == []
+    assert outcome.quality_log == []
+
+
+def test_all_candidates_rejected_yields_empty_roots_populated_quality_log():
+    cands = [
+        candidate(candidate_id="c-1", evidence_count=3),
+        candidate(candidate_id="c-2", coverage=0.05),
+    ]
+    outcome = Validator().validate(cands, FULL_CTX)
+    assert outcome.roots == []
+    assert outcome.tendencies == []
+    assert {e.candidate_id for e in outcome.quality_log} == {"c-1", "c-2"}
+
+
+def test_mixed_batch_partitions_into_three_sections():
+    cands = [
+        candidate(candidate_id="c-root"),  # clean -> root
+        candidate(candidate_id="c-tend", confidence=0.4),  # low conf -> tendency
+        candidate(candidate_id="c-art", evidence_count=2),  # tiny -> artifact
+    ]
+    outcome = Validator().validate(cands, FULL_CTX)
+    assert [r.id for r in outcome.roots] == ["c-root"]
+    assert [t.id for t in outcome.tendencies] == ["c-tend"]
+    assert [q.candidate_id for q in outcome.quality_log] == ["c-art"]
+
+
+def test_multiple_failed_tests_accumulate_on_one_tendency():
+    # Low confidence AND low (but evaluated) stability -> both recorded.
+    outcome = Validator().validate(
+        [candidate(confidence=0.4, temporal_stability_score=0.1)], FULL_CTX
+    )
+    failed = set(outcome.tendencies[0].failed_tests)
+    assert {"confidence_floor", "temporal_stability"} <= failed


### PR DESCRIPTION
## What

Slice #62 — the **validation / classification core**: the category-agnostic deep module every derivation pipeline feeds candidates into. A `Candidate` classifies into exactly one of `root` / `tendency` / `artifact_suspect` (decision `bce66b6e`). This is the *single* place the verdict lives — audio/scene/temporal (#63–#65) build `Candidate`s and hand them here; they never classify themselves.

## How

- **`Candidate`** (category-neutral) → **`Validator`** → **`ValidationOutcome`** (the three RootProfile sections `roots[]` / `tendencies[]` / `quality_log[]`, input order preserved). `DatasetContext` (`n_unique_tracks`, `history_span_days`) is passed once per run — it's what the temporal gate depends on.
- **Four V0 tests**, every threshold read from `method_params.validation`, none hardcoded:
  - **G calibration** (`evidence_count_floor`) + **E coverage floor** (`coverage_floors["tendency"]`) = hard floors → `artifact_suspect`, suppressed and logged to `quality_log[]` (G checked first; details match the schema example).
  - **E root floor** (`coverage_floors["root"]`) → `coverage_pass`; **A confidence floor** → `confidence_pass`.
  - **D temporal stability — gated**: evaluated only when the gate is open (`n_unique_tracks > N_THRESHOLD` AND `history_span_days > T_THRESHOLD_DAYS`) *and* a score is present, then must clear the new `temporal_stability_floor`; otherwise `not_evaluated` → forced to `tendency` (we never assert stability we couldn't measure).
  - No promotion test failed → `root`; otherwise `tendency` carrying `failed_tests[]` (`coverage_floor` / `confidence_floor` / `temporal_stability` / `temporal_stability_not_evaluated`; accumulates).
- Adds `ValidationParams.temporal_stability_floor` (default 0.5, `(calibrate)` in #66) and mirrors it into the canonical `schemas/root_profile.v0.example.json`.

## Acceptance criteria (#62)

- [x] Synthetic candidates classify into root/tendency/artifact_suspect per spec
- [x] Temporal-stability gated: below N/T it marks `not_evaluated` and forces `tendency`
- [x] Every rejected candidate lands in `quality_log[]` with its failed test + details
- [x] Thresholds sourced from `method_params`, not hardcoded
- [x] Honest-empty: zero passing candidates → empty `roots[]`, populated `quality_log[]`

## Tests

15 new tests against **synthetic candidates** — no real category pipeline needed yet (per the issue). 63 green; `ruff check` + `ruff format` + pre-commit pass.

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)
