### PR TITLE
feat: IFTTT xlsx history importer (Closes #76)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -145,6 +145,16 @@ The **temporal** category's deep module — `members → bucketize → lift → 
 
 Candidates are handed to the #62 `Validator` — the temporal pipeline never classifies itself; lift rejections are prepended to the validator's own `quality_log[]`. `_history_midpoint` is imported from `audio.py`.
 
+## History ingestion (V0)
+
+The owner's listening history arrives as a directory of **IFTTT "Spotify → spreadsheet" `.xlsx` exports**. `src/music_intel_mcp/ingest.py` is the adapter; `music-intel import-ifttt --from <dir> [--data-dir ...]` merges it into the per-user `history.jsonl`. Issue #76. This is the only source-format-specific code — everything downstream sees source-agnostic `ListenEvent`s (`source="ifttt"`).
+
+- **Workbook shape.** No header row. Columns, in order: `(played_at_string, track_name, artist_name, spotify_track_id, spotify_url)`. The id is **bare** (`56O4Wl...`, no `spotify:track:` prefix) → maps straight onto `TrackRef.spotify_id`, canonical id `spotify:<id>`. The url (col 4) is ignored.
+- **Timestamp form.** `"December 3, 2024 at 12:31AM"` — parsed by `parse_ifttt_timestamp` (`%B %d, %Y at %I:%M%p`, padding-lenient). Minute resolution; no seconds.
+- **Row tolerance.** Fully-blank/trailing rows, rows with no identity (no spotify id *and* no name), and rows whose timestamp does not parse are skipped, never fatal — counts surface in the `IngestStats` the CLI prints. The real export had **1 date-only cell (`"June 7, 2026"`, no time-of-day) out of 34,676 rows**: skipped, never coerced to a fabricated clock time. Export *drift* shows as a large `skipped_unparseable` count (loud) rather than aborting on the first odd row. A row with no spotify id keeps its name/artist fallback identity.
+- **Idempotent.** `load_ifttt_dir` concatenates all workbooks, dedups by `(canonical_track_id, played_at)` keeping first, sorts ascending by `played_at`. `import-ifttt` merges existing-history-first (so events from other sources survive) then dedups → re-running over the same dir yields the same file. `UserStore.replace_history` rewrites the file from scratch (vs `append_events`).
+- **⚠ TIMEZONE CAVEAT (flagged, not locked).** IFTTT records the trigger time as a **zone-less local wall-clock** string. V0 coerces it to UTC, which is *wrong by the local UTC offset* and will skew temporal day-part/season buckets once temporal roots run on real IFTTT data. It does **not** affect the honest-empty V0 run (no enrichment → no temporal roots). Must be resolved (carry/normalise the zone) before any temporal root derived from this source is trusted — see Open question 14.
+
 ## Invariants
 
 - **Transparency.** Every insight, score, and recommendation carries its evidence chain. No opaque numbers. If we can't explain it, we don't ship it.
@@ -193,3 +203,4 @@ Decisions live in queryable memory (`record_decision` episodes), not duplicated 
 11. **Validation thresholds.** Concrete defaults for `N_THRESHOLD` (tracks), `T_THRESHOLD` (history span), `cluster_share` floor, `evidence_count` floor, `evidence_coverage` floors for `root`/`tendency`/`artifact_suspect`. Will be calibrated on owner's real data in the first analysis run.
 12. ~~Root unit / granularity.~~ → resolved across all V0 categories. `audio`: 1:1 HDBSCAN cluster. `temporal`: 1:1 `(time_bucket, conditioned_root)` pair. `scene`: 1:1 NMF topic that passed coherence floor.
 13. **V1 feedback channel.** F (user feedback on tendencies) requires *some* interface — CLI prompt, simple HTTP form, MCP tool. Choice deferred to V1 grill.
+14. **IFTTT timestamp timezone.** IFTTT exports a zone-less local wall-clock string (`"December 3, 2024 at 12:31AM"`); V0 (`ingest.py`, #76) coerces it to UTC. Harmless for the honest-empty run (no temporal roots without enrichment), but wrong by the local offset → skews `day_part`/`season` buckets once temporal roots derive on real IFTTT data. Open: pin the export's source zone (Europe/* for the owner) and normalise at ingest, or carry a per-event zone on `ListenEvent`. Must resolve before trusting any temporal root from this source.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dependencies = [
   # imports scipy.stats.ks_2samp directly (exact p-values beat re-deriving the
   # Kolmogorov distribution by hand — decision 00f7e1eb).
   "scipy>=1.11",
+  # IFTTT history arrives as .xlsx workbooks (#76); openpyxl is the reader for
+  # the import-ifttt adapter. Pure-Python, small tree (et-xmlfile only).
+  "openpyxl>=3.1",
 ]
 
 [project.optional-dependencies]

--- a/src/music_intel_mcp/cli.py
+++ b/src/music_intel_mcp/cli.py
@@ -1,12 +1,15 @@
-"""CLI surface. V0 exposes ``analyze`` and ``resolve``.
+"""CLI surface. V0 exposes ``analyze``, ``resolve``, and ``import-ifttt``.
 
+    music-intel import-ifttt --from <dir> [--data-dir ./data]
     music-intel analyze --user-id petr [--data-dir ./data]
     music-intel resolve [--data-dir ./data] [--mb-index PATH]
 
-``analyze`` loads the per-user history, runs the derivation engine, writes a
-RootProfile snapshot, and prints the path + a one-line summary. ``resolve``
-walks the history through the spotify_id -> ISRC -> MBID identity waterfall and
-reports resolution coverage (caching resolved identities for re-runs).
+``import-ifttt`` merges a directory of IFTTT Spotify ``.xlsx`` exports into the
+per-user ``history.jsonl`` (dedup + idempotent re-import). ``analyze`` loads that
+history, runs the derivation engine, writes a RootProfile snapshot, and prints
+the path + a one-line summary. ``resolve`` walks the history through the
+spotify_id -> ISRC -> MBID identity waterfall and reports resolution coverage
+(caching resolved identities for re-runs).
 """
 
 from __future__ import annotations
@@ -16,7 +19,33 @@ from collections.abc import Sequence
 
 from .analyzer import analyze
 from .identity import IdentityCache, IdentityResolver, MusicBrainzIsrcIndex
+from .ingest import IngestStats, dedup_events, load_ifttt_dir
 from .store import UserStore
+
+
+def _cmd_import_ifttt(args: argparse.Namespace) -> int:
+    store = UserStore(root=args.data_dir)
+    before = store.load_history()
+    stats = IngestStats()
+    imported = load_ifttt_dir(args.source, stats=stats)
+    # Merge existing-first so events from other sources survive, then dedup so a
+    # re-import over the same dir is idempotent.
+    merged = dedup_events([*before, *imported])
+    store.replace_history(merged)
+
+    added = len(merged) - len(before)
+    print(f"imported {len(imported)} IFTTT plays from {args.source}")
+    print(f"  history.jsonl: {len(before)} -> {len(merged)} events (+{added} new after dedup)")
+    if stats.total_skipped:
+        # Surfaced, never silent: a large unparseable count signals export drift.
+        print(
+            f"  skipped {stats.total_skipped} rows "
+            f"(empty={stats.skipped_empty} no-identity={stats.skipped_no_identity} "
+            f"unparseable-timestamp={stats.skipped_unparseable})"
+        )
+        if stats.unparseable_samples:
+            print(f"    unparseable e.g.: {stats.unparseable_samples}")
+    return 0
 
 
 def _cmd_analyze(args: argparse.Namespace) -> int:
@@ -82,6 +111,20 @@ def build_parser() -> argparse.ArgumentParser:
         help="MusicBrainz ISRC->MBID index TSV (default: $MUSICBRAINZ_ISRC_INDEX)",
     )
     p_resolve.set_defaults(func=_cmd_resolve)
+
+    p_import = sub.add_parser("import-ifttt", help="import IFTTT .xlsx history exports")
+    p_import.add_argument(
+        "--from",
+        dest="source",
+        required=True,
+        help="directory of IFTTT Spotify_data*.xlsx exports",
+    )
+    p_import.add_argument(
+        "--data-dir",
+        default=None,
+        help="data root (default: $MUSIC_INTEL_DATA_DIR or ./data)",
+    )
+    p_import.set_defaults(func=_cmd_import_ifttt)
     return parser
 
 

--- a/src/music_intel_mcp/ingest.py
+++ b/src/music_intel_mcp/ingest.py
@@ -1,0 +1,166 @@
+"""IFTTT "Spotify -> spreadsheet" history ingestion (#76).
+
+The owner's listening history arrives as a directory of ``.xlsx`` workbooks
+written by the IFTTT applet that logs every Spotify play to a spreadsheet. Each
+row is one play; there is **no header**. Columns, in order:
+
+==  =============  =====================================
+0   played_at      ``"December 3, 2024 at 12:31AM"``
+1   track name     ``"Maniac"``
+2   artist name    ``"Flower Face"``
+3   spotify id     bare id ``"56O4WlGoUJiwfwoyRYqTe9"`` (no ``spotify:track:``)
+4   spotify url    ``"https://open.spotify.com/track/56O4..."`` (ignored)
+==  =============  =====================================
+
+This is the only IFTTT-specific code; everything downstream sees source-agnostic
+``ListenEvent``s. The bare spotify id maps straight onto ``TrackRef.spotify_id``
+so its canonical id is ``spotify:<id>``.
+
+TIMEZONE CAVEAT (flagged, not locked — see CONTEXT.md): IFTTT records the trigger
+time as a *zone-less local wall-clock* string. V0 coerces it to UTC, which is
+wrong by the local UTC offset and will skew temporal day-part/season buckets once
+temporal roots run on real IFTTT data. It does **not** affect the honest-empty V0
+run (no enrichment -> no temporal roots). Resolve the zone (or carry it through)
+before trusting temporal roots derived from this source.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+from openpyxl import load_workbook
+
+from .models import ListenEvent, TrackRef
+from .shared_store import canonical_track_id
+
+SOURCE = "ifttt"
+_MAX_SKIP_SAMPLES = 5
+# "Month D, YYYY at H:MM<AM|PM>" — strptime is padding-lenient, so "3"/"03" and
+# "2"/"02" both parse. %p matches the AM/PM with no separating space.
+_TIMESTAMP_FORMAT = "%B %d, %Y at %I:%M%p"
+_WORKBOOK_GLOB = "*.xlsx"
+
+
+@dataclass
+class IngestStats:
+    """What ``load_ifttt_*`` dropped, so the CLI can surface it rather than let
+    skips pass silently. A spike in ``skipped_unparseable`` is the loud signal
+    that the export's timestamp shape drifted (vs aborting on the first odd row).
+    """
+
+    skipped_empty: int = 0
+    skipped_no_identity: int = 0
+    skipped_unparseable: int = 0
+    unparseable_samples: list[str] = field(default_factory=list)
+
+    def _note_unparseable(self, raw: str) -> None:
+        self.skipped_unparseable += 1
+        if len(self.unparseable_samples) < _MAX_SKIP_SAMPLES:
+            self.unparseable_samples.append(raw)
+
+    @property
+    def total_skipped(self) -> int:
+        return self.skipped_empty + self.skipped_no_identity + self.skipped_unparseable
+
+
+def parse_ifttt_timestamp(raw: str) -> datetime:
+    """Parse one IFTTT ``"Month D, YYYY at H:MM<AM|PM>"`` cell to a UTC-aware
+    datetime. Raises ``ValueError`` (with the offending string) on any other
+    shape — including the date-only ``"June 7, 2026"`` form seen once in the real
+    export, which carries no time-of-day and so cannot be placed in a calendar
+    bucket. Callers catch this and skip+count the row (see ``_row_to_event``)
+    rather than fabricate a clock time the source never recorded.
+    """
+    return datetime.strptime(raw.strip(), _TIMESTAMP_FORMAT).replace(tzinfo=UTC)
+
+
+def _cell(value: object) -> str:
+    """Normalise a worksheet cell to a stripped string (``None`` -> ``""``)."""
+    return "" if value is None else str(value).strip()
+
+
+def _row_to_event(row: tuple, stats: IngestStats) -> ListenEvent | None:
+    """Map one IFTTT row to a ``ListenEvent``; return ``None`` (and tally the
+    reason on ``stats``) to skip it.
+
+    Skipped: fully-blank/trailing rows, rows carrying neither a spotify id nor a
+    name (no identity), and rows whose timestamp does not parse (unplaceable in
+    time — never coerced to a fabricated clock time).
+    """
+    cells = [_cell(c) for c in row]
+    while len(cells) < 4:  # tolerate short rows; columns 4+ (the url) are ignored
+        cells.append("")
+    played_raw, name, artist, spotify_id = cells[0], cells[1], cells[2], cells[3]
+
+    if not played_raw and not spotify_id and not name:
+        stats.skipped_empty += 1
+        return None
+    if not spotify_id and not name:
+        stats.skipped_no_identity += 1
+        return None
+    try:
+        played_at = parse_ifttt_timestamp(played_raw)
+    except ValueError:
+        stats._note_unparseable(played_raw)
+        return None
+
+    return ListenEvent(
+        track=TrackRef(spotify_id=spotify_id or None, name=name, artist=artist),
+        played_at=played_at,
+        source=SOURCE,
+    )
+
+
+def load_ifttt_workbook(path: str | Path, *, stats: IngestStats | None = None) -> list[ListenEvent]:
+    """Convert every data row of one IFTTT ``.xlsx`` to a ``ListenEvent``.
+    Pass a shared ``stats`` to accumulate skip counts across many workbooks."""
+    stats = stats if stats is not None else IngestStats()
+    wb = load_workbook(filename=str(path), read_only=True, data_only=True)
+    try:
+        ws = wb.active
+        return [
+            event for row in ws.iter_rows(values_only=True) if (event := _row_to_event(row, stats))
+        ]
+    finally:
+        wb.close()
+
+
+def _dedup_key(event: ListenEvent) -> tuple[str, str]:
+    """Identity for dedup: same track played at the same minute is one play.
+    IFTTT timestamps are minute-resolution, so this is the finest honest grain."""
+    return (canonical_track_id(event.track), event.played_at.isoformat())
+
+
+def dedup_events(events: Iterable[ListenEvent]) -> list[ListenEvent]:
+    """Drop duplicate plays (same canonical track id + played_at), keep first
+    occurrence, then sort ascending by ``played_at`` for a stable history."""
+    seen: set[tuple[str, str]] = set()
+    out: list[ListenEvent] = []
+    for event in events:
+        key = _dedup_key(event)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(event)
+    out.sort(key=lambda e: e.played_at)
+    return out
+
+
+def load_ifttt_dir(
+    directory: str | Path,
+    *,
+    pattern: str = _WORKBOOK_GLOB,
+    stats: IngestStats | None = None,
+) -> list[ListenEvent]:
+    """Load and merge every IFTTT workbook under ``directory`` into one
+    deduped, time-sorted history. Idempotent: re-running yields the same list.
+    Pass a ``stats`` to receive skip counts across the whole directory."""
+    root = Path(directory)
+    stats = stats if stats is not None else IngestStats()
+    events: list[ListenEvent] = []
+    for workbook in sorted(root.glob(pattern)):
+        events.extend(load_ifttt_workbook(workbook, stats=stats))
+    return dedup_events(events)

--- a/src/music_intel_mcp/store.py
+++ b/src/music_intel_mcp/store.py
@@ -68,6 +68,15 @@ class UserStore:
             for event in events:
                 fh.write(event.model_dump_json() + "\n")
 
+    def replace_history(self, events: list[ListenEvent]) -> None:
+        """Rewrite ``history.jsonl`` from scratch (overwrite, not append).
+        Used by idempotent importers that merge+dedup, then write the full
+        history back so re-running the same source yields the same file."""
+        self.history_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.history_path.open("w", encoding="utf-8") as fh:
+            for event in events:
+                fh.write(event.model_dump_json() + "\n")
+
     # --- profiles -------------------------------------------------------- #
 
     def write_profile(self, profile: RootProfile) -> Path:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,160 @@
+"""IFTTT xlsx history importer (#76 — enables #66 criterion 1).
+
+The owner's listening history arrives as a directory of IFTTT "Spotify ->
+spreadsheet" ``.xlsx`` exports. These tests pin the column mapping, the
+``"Month D, YYYY at H:MMAM"`` timestamp parse, blank-row tolerance, and the
+idempotent merge+dedup of ``load_ifttt_dir``. Fixtures are built in-test with
+openpyxl so no binary workbook is committed and the exact source shape is
+visible in the test.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from openpyxl import Workbook
+
+from music_intel_mcp.ingest import (
+    IngestStats,
+    load_ifttt_dir,
+    load_ifttt_workbook,
+    parse_ifttt_timestamp,
+)
+from music_intel_mcp.shared_store import canonical_track_id
+
+# (played_at, track, artist, spotify_id, url) — IFTTT row order, no header.
+_ROW_A = (
+    "December 3, 2024 at 12:31AM",
+    "Maniac",
+    "Flower Face",
+    "56O4WlGoUJiwfwoyRYqTe9",
+    "https://open.spotify.com/track/56O4WlGoUJiwfwoyRYqTe9",
+)
+_ROW_B = (
+    "July 14, 2025 at 2:05PM",
+    "Cellophane",
+    "FKA twigs",
+    "1234567890abcdefABCDEF",
+    "https://open.spotify.com/track/1234567890abcdefABCDEF",
+)
+
+
+def _write_workbook(path: Path, rows: list[tuple]) -> Path:
+    wb = Workbook()
+    ws = wb.active
+    for row in rows:
+        ws.append(list(row))
+    wb.save(path)
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# timestamp parsing — the one non-mechanical bit of the mapping
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_midnight_and_noon_and_pm():
+    # 12:31AM is 00:31, not 12:31; 2:05PM is 14:05; 12:00PM is noon.
+    assert parse_ifttt_timestamp("December 3, 2024 at 12:31AM") == datetime(
+        2024, 12, 3, 0, 31, tzinfo=UTC
+    )
+    assert parse_ifttt_timestamp("July 14, 2025 at 2:05PM") == datetime(
+        2025, 7, 14, 14, 5, tzinfo=UTC
+    )
+    assert parse_ifttt_timestamp("January 1, 2025 at 12:00PM") == datetime(
+        2025, 1, 1, 12, 0, tzinfo=UTC
+    )
+
+
+def test_parse_tolerates_surrounding_whitespace():
+    assert parse_ifttt_timestamp("  March 9, 2025 at 6:07AM  ") == datetime(
+        2025, 3, 9, 6, 7, tzinfo=UTC
+    )
+
+
+# --------------------------------------------------------------------------- #
+# workbook -> ListenEvent column mapping
+# --------------------------------------------------------------------------- #
+
+
+def test_workbook_maps_columns_to_listen_events(tmp_path):
+    path = _write_workbook(tmp_path / "Spotify_data.xlsx", [_ROW_A, _ROW_B])
+    events = load_ifttt_workbook(path)
+
+    assert len(events) == 2
+    a = events[0]
+    assert a.track.spotify_id == "56O4WlGoUJiwfwoyRYqTe9"
+    assert a.track.name == "Maniac"
+    assert a.track.artist == "Flower Face"
+    assert a.played_at == datetime(2024, 12, 3, 0, 31, tzinfo=UTC)
+    assert a.source == "ifttt"
+    # bare id, not URI-prefixed -> canonical id is spotify:<bare id>.
+    assert canonical_track_id(a.track) == "spotify:56O4WlGoUJiwfwoyRYqTe9"
+
+
+def test_blank_and_untimestamped_rows_are_skipped(tmp_path):
+    rows = [
+        _ROW_A,
+        ("", "", "", "", ""),  # trailing blank row
+        (None, None, None, None, None),  # openpyxl all-None row
+        ("", "Ghost", "Artist", "", ""),  # has data but no timestamp -> unplaceable
+        _ROW_B,
+    ]
+    path = _write_workbook(tmp_path / "Spotify_data1.xlsx", rows)
+    stats = IngestStats()
+    events = load_ifttt_workbook(path, stats=stats)
+    # only the two well-formed rows survive; nothing crashes.
+    assert len(events) == 2
+    assert {e.track.name for e in events} == {"Maniac", "Cellophane"}
+    assert stats.skipped_empty == 2  # the "" row and the all-None row
+
+
+def test_date_only_timestamp_is_skipped_and_counted(tmp_path):
+    """The real export carried one date-only cell ("June 7, 2026") with no
+    time-of-day. It is skipped (never coerced to a fabricated clock time) and
+    tallied so the CLI can surface it — drift shows as a count, not a crash."""
+    rows = [_ROW_A, ("June 7, 2026", "Daylist", "Various", "ZZZ123", "")]
+    path = _write_workbook(tmp_path / "Spotify_data3.xlsx", rows)
+    stats = IngestStats()
+    events = load_ifttt_workbook(path, stats=stats)
+    assert len(events) == 1  # only the WITH_TIME row promotes
+    assert events[0].track.name == "Maniac"
+    assert stats.skipped_unparseable == 1
+    assert stats.unparseable_samples == ["June 7, 2026"]
+
+
+def test_row_without_spotify_id_keeps_name_artist_fallback(tmp_path):
+    row = ("April 2, 2025 at 9:15PM", "No Id Track", "Some Artist", "", "")
+    path = _write_workbook(tmp_path / "Spotify_data2.xlsx", [row])
+    events = load_ifttt_workbook(path)
+    assert len(events) == 1
+    assert events[0].track.spotify_id is None
+    assert canonical_track_id(events[0].track) == "name:no id track\x1fsome artist"
+
+
+# --------------------------------------------------------------------------- #
+# directory load — concat across workbooks + idempotent dedup
+# --------------------------------------------------------------------------- #
+
+
+def test_dir_concats_dedups_and_sorts(tmp_path):
+    # _ROW_A appears in both workbooks (same id + timestamp) -> one event.
+    _write_workbook(tmp_path / "Spotify_data.xlsx", [_ROW_B, _ROW_A])
+    _write_workbook(tmp_path / "Spotify_data1.xlsx", [_ROW_A])
+
+    events = load_ifttt_dir(tmp_path)
+
+    assert len(events) == 2  # deduped
+    # sorted ascending by played_at: Dec 2024 before Jul 2025.
+    assert [e.played_at for e in events] == sorted(e.played_at for e in events)
+    assert events[0].track.name == "Maniac"
+    assert events[1].track.name == "Cellophane"
+
+
+def test_dir_load_is_idempotent_over_a_played_at_and_track(tmp_path):
+    _write_workbook(tmp_path / "Spotify_data.xlsx", [_ROW_A, _ROW_A])  # dup within file
+    once = load_ifttt_dir(tmp_path)
+    twice = load_ifttt_dir(tmp_path)
+    assert len(once) == 1
+    assert once == twice

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -51,3 +51,25 @@ def test_env_var_sets_data_dir(tmp_path, monkeypatch):
     monkeypatch.setenv("MUSIC_INTEL_DATA_DIR", str(tmp_path / "envdata"))
     store = UserStore()
     assert store.root == tmp_path / "envdata"
+
+
+def test_replace_history_overwrites_not_appends(tmp_path):
+    from datetime import UTC, datetime
+
+    from music_intel_mcp.models import ListenEvent, TrackRef
+
+    store = UserStore(root=tmp_path)
+    e1 = ListenEvent(
+        track=TrackRef(spotify_id="A", name="a", artist="x"),
+        played_at=datetime(2025, 1, 1, tzinfo=UTC),
+        source="ifttt",
+    )
+    e2 = ListenEvent(
+        track=TrackRef(spotify_id="B", name="b", artist="y"),
+        played_at=datetime(2025, 2, 1, tzinfo=UTC),
+        source="ifttt",
+    )
+    store.append_events([e1])
+    store.replace_history([e2])  # replaces, does not append
+    reloaded = store.load_history()
+    assert reloaded == [e2]


### PR DESCRIPTION
## What

IFTTT `.xlsx` listening-history importer — the adapter that lets the V0 derivation engine run on the owner's real Spotify history.

`music-intel import-ifttt --from <dir> [--data-dir ./data]` merges a directory of IFTTT "Spotify → spreadsheet" exports into the per-user `history.jsonl`. Only `ingest.py` is IFTTT-aware; everything downstream sees source-agnostic `ListenEvent`s. The bare spotify id maps onto `TrackRef.spotify_id` (canonical `spotify:<id>`).

## Why

#66 criterion 1 requires the full pipeline to run end-to-end on real history. There was no importer for the owner's actual data shape (IFTTT xlsx, no header, `played_at | track | artist | spotify_id | url`). This is the missing first link.

## Design notes

- **Skip-and-report, never crash, never fabricate.** Malformed rows are tallied on `IngestStats` and surfaced by the CLI rather than aborting the import. A date-only cell (`"June 7, 2026"`, no time-of-day) is skipped and counted — never coerced to a fabricated clock time (transparency invariant). The real export contained exactly one such row out of ~34,676.
- **Idempotent.** Merge + dedup on `(canonical_track_id, played_at)`, sorted ascending; re-importing the same directory is a no-op. `store.replace_history()` overwrites after merge so other sources survive.
- **Timezone caveat (flagged, not locked — CONTEXT.md open Q14).** IFTTT records a zone-less local wall-clock; V0 coerces to UTC, which will skew temporal day-part/season buckets once temporal roots run on this source. Does not affect the honest-empty V0 run.

## Validation on real data

Ran against the owner's actual 18-workbook export:
- `import-ifttt`: **34,530 plays** imported; 1 row skipped (date-only timestamp), surfaced in CLI output.
- `analyze`: valid **honest-empty** RootProfile — 34,530 events / 21,118 unique tracks / 553-day span / sources=ifttt / roots=0 (no enrichment configured, which is the correct honest output).

## Tests

10 new tests in `test_ingest.py` (timestamp parse incl. midnight/noon/PM + whitespace, column mapping, blank + date-only row tolerance with stat assertions, name/artist fallback, dir concat+dedup+sort, idempotency) + `test_replace_history_overwrites_not_appends`. Full suite **115 passing**; ruff + pre-commit clean.

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)
