### PR TITLE
feat: wire enrichment sources into the analyze CLI (#78)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -155,6 +155,15 @@ The owner's listening history arrives as a directory of **IFTTT "Spotify → spr
 - **Idempotent.** `load_ifttt_dir` concatenates all workbooks, dedups by `(canonical_track_id, played_at)` keeping first, sorts ascending by `played_at`. `import-ifttt` merges existing-history-first (so events from other sources survive) then dedups → re-running over the same dir yields the same file. `UserStore.replace_history` rewrites the file from scratch (vs `append_events`).
 - **⚠ TIMEZONE CAVEAT (flagged, not locked).** IFTTT records the trigger time as a **zone-less local wall-clock** string. V0 coerces it to UTC, which is *wrong by the local UTC offset* and will skew temporal day-part/season buckets once temporal roots run on real IFTTT data. It does **not** affect the honest-empty V0 run (no enrichment → no temporal roots). Must be resolved (carry/normalise the zone) before any temporal root derived from this source is trusted — see Open question 14.
 
+## Analyze CLI — enrichment surface (V0)
+
+`music-intel analyze --user-id <id> [--data-dir ...]` loads the per-user `history.jsonl`, runs the derivation engine, writes a RootProfile snapshot, and prints a one-line summary plus per-category `coverage:` (audio/scene/temporal). Issue #78. The pipelines are locked (#63/#64); the CLI only *wires* the already-built source adapters into `analyze()` — no new domain logic.
+
+- **Enrichment is off by default.** With no `--with-*` flag, `analyze` constructs no sources and emits the honest-empty V0 baseline (the audio/scene stages are opt-in by dependency, so they stay silent). This default is regression-guarded by the CLI tests.
+- **Opt-in flags.** `--with-audio` runs the audio stage (needs an `AcousticBrainz` dump); `--with-scene` runs the scene stage (needs `LASTFM_API_KEY`). `--ab-index PATH` overrides the dump location (else `$ACOUSTICBRAINZ_FEATURES_INDEX` → `$ACOUSTICBRAINZ_DUMP_DIR/acousticbrainz_features.jsonl`). `--shared-store {supabase,memory}` (default `supabase`) chooses the metadata store; `memory` is an ephemeral single-run store needing no creds.
+- **Fail-fast on missing credentials, presence-only.** `plan_enrichment(args, env)` resolves flags → sources purely (offline, unit-tested). A flag whose credential is absent (`--with-scene` without `LASTFM_API_KEY`; `--shared-store supabase` without `SUPABASE_URL`+`SUPABASE_KEY`) aborts **before** touching history/store with a clear `error:` line and exit code 2. The env is checked for **presence only** — the secret value is never read or printed.
+- **Empty coverage is honest, not an error.** A dump that isn't installed or tracks that don't resolve to MBIDs yield `audio=0.00` (rc 0) plus a diagnostic `note:` — distinct from the credential-missing abort. A missing dump file is an empty index, never a crash (`AcousticBrainzDump` resolves its path lazily).
+
 ## Invariants
 
 - **Transparency.** Every insight, score, and recommendation carries its evidence chain. No opaque numbers. If we can't explain it, we don't ship it.

--- a/src/music_intel_mcp/cli.py
+++ b/src/music_intel_mcp/cli.py
@@ -2,6 +2,8 @@
 
     music-intel import-ifttt --from <dir> [--data-dir ./data]
     music-intel analyze --user-id petr [--data-dir ./data]
+                        [--with-audio] [--with-scene]
+                        [--ab-index PATH] [--shared-store supabase|memory]
     music-intel resolve [--data-dir ./data] [--mb-index PATH]
 
 ``import-ifttt`` merges a directory of IFTTT Spotify ``.xlsx`` exports into the
@@ -10,17 +12,82 @@ history, runs the derivation engine, writes a RootProfile snapshot, and prints
 the path + a one-line summary. ``resolve`` walks the history through the
 spotify_id -> ISRC -> MBID identity waterfall and reports resolution coverage
 (caching resolved identities for re-runs).
+
+Enrichment is **off by default**: with no ``--with-*`` flag ``analyze`` produces
+an honest-empty profile (the V0 baseline). ``--with-audio`` / ``--with-scene``
+opt the run into the audio / scene derivation stages by constructing the
+production source adapters (the env-pointed :class:`AcousticBrainzDump` and the
+``LASTFM_API_KEY``-backed :class:`LastfmTagSource`) plus a shared metadata store,
+then handing them to :func:`analyze`. The pipelines themselves are locked
+(#63/#64); this module only wires the already-built adapters to the CLI.
 """
 
 from __future__ import annotations
 
 import argparse
-from collections.abc import Sequence
+import os
+from collections.abc import Mapping, Sequence
 
 from .analyzer import analyze
+from .audio import AcousticBrainzDump, AudioFeatureSource
 from .identity import IdentityCache, IdentityResolver, MusicBrainzIsrcIndex
 from .ingest import IngestStats, dedup_events, load_ifttt_dir
+from .scene import LastfmTagSource, TagSource
+from .shared_store import InMemorySharedStore, SharedStore, SupabaseSharedStore
 from .store import UserStore
+
+# Canonical env-var names this CLI checks for *presence* (never value) before an
+# enrichment run, so a missing credential fails fast with a clear message rather
+# than mid-pipeline. They mirror the constants owned by ``scene``/``shared_store``
+# (kept as literals here because they are the CLI's documented env contract).
+_LASTFM_API_KEY_ENV = "LASTFM_API_KEY"
+_SUPABASE_URL_ENV = "SUPABASE_URL"
+_SUPABASE_KEY_ENV = "SUPABASE_KEY"
+
+
+def _build_shared_store(kind: str) -> SharedStore:
+    """Construct the requested :class:`SharedStore`. ``memory`` is an ephemeral
+    single-run store (no persistence, no creds); ``supabase`` is the production
+    shared cache (lazy client — no network until first read/write)."""
+    if kind == "memory":
+        return InMemorySharedStore()
+    return SupabaseSharedStore()
+
+
+def plan_enrichment(
+    args: argparse.Namespace,
+    env: Mapping[str, str],
+) -> tuple[SharedStore | None, AudioFeatureSource | None, TagSource | None, list[str]]:
+    """Resolve the ``--with-*`` flags against ``env`` into enrichment sources.
+
+    Returns ``(shared_store, audio_source, tag_source, errors)``. With no
+    ``--with-*`` flag every source is ``None`` and ``errors`` is empty — the
+    honest-empty baseline, unchanged. When a flag is set, required credentials
+    are checked for *presence* (never read or printed); any missing one is
+    appended to ``errors`` and all sources come back ``None`` so the caller can
+    abort before touching history or the store. No network/dump access happens
+    here — adapters are constructed lazily and only read when ``analyze`` runs.
+    """
+    errors: list[str] = []
+    if not (args.with_audio or args.with_scene):
+        return None, None, None, errors
+
+    if args.shared_store == "supabase" and not (
+        env.get(_SUPABASE_URL_ENV) and env.get(_SUPABASE_KEY_ENV)
+    ):
+        errors.append(
+            f"--shared-store supabase needs {_SUPABASE_URL_ENV} and {_SUPABASE_KEY_ENV} set "
+            "(or use --shared-store memory for an ephemeral local run)."
+        )
+    if args.with_scene and not env.get(_LASTFM_API_KEY_ENV):
+        errors.append(f"--with-scene needs {_LASTFM_API_KEY_ENV} set.")
+    if errors:
+        return None, None, None, errors
+
+    shared_store = _build_shared_store(args.shared_store)
+    audio_source = AcousticBrainzDump(path=args.ab_index) if args.with_audio else None
+    tag_source = LastfmTagSource() if args.with_scene else None
+    return shared_store, audio_source, tag_source, errors
 
 
 def _cmd_import_ifttt(args: argparse.Namespace) -> int:
@@ -49,21 +116,49 @@ def _cmd_import_ifttt(args: argparse.Namespace) -> int:
 
 
 def _cmd_analyze(args: argparse.Namespace) -> int:
-    store = UserStore(root=args.data_dir)
-    events = store.load_history()
-    profile = analyze(events, user_id=args.user_id)
-    path = store.write_profile(profile)
+    shared_store, audio_source, tag_source, errors = plan_enrichment(args, os.environ)
+    if errors:
+        for err in errors:
+            print(f"error: {err}")
+        return 2
+
+    user_store = UserStore(root=args.data_dir)
+    events = user_store.load_history()
+    profile = analyze(
+        events,
+        user_id=args.user_id,
+        shared_store=shared_store,
+        audio_source=audio_source,
+        tag_source=tag_source,
+    )
+    path = user_store.write_profile(profile)
 
     gf = profile.generated_from
+    cov = gf.coverage_per_category
     print(f"snapshot: {path}")
     print(
         f"  events={gf.n_events} unique_tracks={gf.n_unique_tracks} "
         f"span_days={gf.history_span_days} sources={','.join(gf.data_sources) or '-'}"
     )
     print(
+        f"  coverage: audio={cov.get('audio', 0.0):.2f} "
+        f"scene={cov.get('scene', 0.0):.2f} temporal={cov.get('temporal', 0.0):.2f}"
+    )
+    print(
         f"  roots={len(profile.roots)} tendencies={len(profile.tendencies)} "
         f"epochs={len(profile.epochs)} maturity={profile.model_maturity}"
     )
+    # Honest diagnostic: an enrichment flag that yielded zero coverage means the
+    # source had nothing (dump not installed / no MBIDs / Last.fm misses), not a
+    # bug — surface it so a real run isn't silently empty.
+    if args.with_audio and cov.get("audio", 0.0) == 0.0:
+        print(
+            "  note: audio coverage 0 — check the AcousticBrainz dump "
+            "(--ab-index / ACOUSTICBRAINZ_FEATURES_INDEX / ACOUSTICBRAINZ_DUMP_DIR) "
+            "and that tracks resolve to MBIDs (run `resolve` first)."
+        )
+    if args.with_scene and cov.get("scene", 0.0) == 0.0:
+        print("  note: scene coverage 0 — Last.fm returned no tags for any track.")
     return 0
 
 
@@ -96,6 +191,29 @@ def build_parser() -> argparse.ArgumentParser:
         "--data-dir",
         default=None,
         help="data root (default: $MUSIC_INTEL_DATA_DIR or ./data)",
+    )
+    p_analyze.add_argument(
+        "--with-audio",
+        action="store_true",
+        help="run the audio derivation stage (needs an AcousticBrainz dump)",
+    )
+    p_analyze.add_argument(
+        "--with-scene",
+        action="store_true",
+        help="run the scene derivation stage (needs LASTFM_API_KEY)",
+    )
+    p_analyze.add_argument(
+        "--ab-index",
+        default=None,
+        help="AcousticBrainz features JSONL (default: $ACOUSTICBRAINZ_FEATURES_INDEX "
+        "or $ACOUSTICBRAINZ_DUMP_DIR/acousticbrainz_features.jsonl)",
+    )
+    p_analyze.add_argument(
+        "--shared-store",
+        choices=["supabase", "memory"],
+        default="supabase",
+        help="metadata store for enrichment: 'supabase' (shared cache) or "
+        "'memory' (ephemeral, single-run). Default: supabase.",
     )
     p_analyze.set_defaults(func=_cmd_analyze)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,14 +1,26 @@
-"""CLI `analyze` + `resolve` entrypoints."""
+"""CLI `analyze` + `resolve` + enrichment-wiring entrypoints."""
 
 from __future__ import annotations
 
 import shutil
+from datetime import UTC, datetime
 from pathlib import Path
 
-from music_intel_mcp.cli import main
+import music_intel_mcp.cli as cli
+from music_intel_mcp.audio import AcousticBrainzDump
+from music_intel_mcp.cli import build_parser, main, plan_enrichment
+from music_intel_mcp.models import ListenEvent, TrackRef
+from music_intel_mcp.scene import InMemoryTagSource, LastfmTagSource
+from music_intel_mcp.shared_store import InMemorySharedStore, SupabaseSharedStore, TrackTag
 from music_intel_mcp.store import UserStore
 
 FIXTURE_INDEX = Path(__file__).parent / "fixtures" / "isrc_mbid_index.tsv"
+
+
+def _analyze_args(*extra: str):
+    """Parse an ``analyze`` argv through the real parser (so the flags are
+    exercised too) and return the resulting namespace."""
+    return build_parser().parse_args(["analyze", "--user-id", "petr", *extra])
 
 
 def test_cli_analyze_writes_snapshot(tmp_path, history_sample_path, capsys):
@@ -37,6 +49,15 @@ def test_cli_analyze_empty_history(tmp_path, capsys):
     assert "roots=0" in out
 
 
+def test_cli_analyze_prints_per_category_coverage(tmp_path, history_sample_path, capsys):
+    """The honest-empty default prints coverage with no enrichment run: audio and
+    scene are 0 (no source), temporal is 1.0 (every event carries a timestamp)."""
+    shutil.copy(history_sample_path, tmp_path / "history.jsonl")
+    rc = main(["analyze", "--user-id", "petr", "--data-dir", str(tmp_path)])
+    assert rc == 0
+    assert "coverage: audio=0.00 scene=0.00 temporal=1.00" in capsys.readouterr().out
+
+
 def test_cli_resolve_reports_coverage(tmp_path, history_sample_path, capsys):
     shutil.copy(history_sample_path, tmp_path / "history.jsonl")
     rc = main(["resolve", "--data-dir", str(tmp_path), "--mb-index", str(FIXTURE_INDEX)])
@@ -50,3 +71,170 @@ def test_cli_resolve_reports_coverage(tmp_path, history_sample_path, capsys):
 
     # identities are cached for re-runs
     assert (tmp_path / "identity").is_dir()
+
+
+# --------------------------------------------------------------------------- #
+# plan_enrichment — flag/env matrix (pure, fully offline)
+# --------------------------------------------------------------------------- #
+
+
+def test_plan_enrichment_no_flags_is_honest_empty():
+    store, audio, tag, errors = plan_enrichment(_analyze_args(), {})
+    assert (store, audio, tag, errors) == (None, None, None, [])
+
+
+def test_plan_enrichment_scene_requires_lastfm_key():
+    args = _analyze_args("--with-scene", "--shared-store", "memory")
+    store, audio, tag, errors = plan_enrichment(args, {})  # no key present
+    assert store is None and audio is None and tag is None
+    assert any("LASTFM_API_KEY" in e for e in errors)
+
+
+def test_plan_enrichment_scene_memory_store_ok():
+    args = _analyze_args("--with-scene", "--shared-store", "memory")
+    store, audio, tag, errors = plan_enrichment(args, {"LASTFM_API_KEY": "present"})
+    assert errors == []
+    assert isinstance(store, InMemorySharedStore)
+    assert audio is None
+    assert isinstance(tag, LastfmTagSource)
+
+
+def test_plan_enrichment_audio_constructs_dump_with_ab_index(tmp_path):
+    args = _analyze_args(
+        "--with-audio", "--shared-store", "memory", "--ab-index", str(tmp_path / "x.jsonl")
+    )
+    store, audio, tag, errors = plan_enrichment(args, {})
+    assert errors == []
+    assert isinstance(store, InMemorySharedStore)
+    assert isinstance(audio, AcousticBrainzDump)
+    assert tag is None
+
+
+def test_plan_enrichment_supabase_requires_creds():
+    # default --shared-store is supabase
+    store, audio, tag, errors = plan_enrichment(_analyze_args("--with-audio"), {})
+    assert store is None
+    assert any("SUPABASE_URL" in e for e in errors)
+
+
+def test_plan_enrichment_supabase_with_creds_ok():
+    args = _analyze_args("--with-audio")
+    env = {"SUPABASE_URL": "u", "SUPABASE_KEY": "k"}
+    store, audio, tag, errors = plan_enrichment(args, env)
+    assert errors == []
+    assert isinstance(store, SupabaseSharedStore)
+    assert isinstance(audio, AcousticBrainzDump)
+
+
+def test_plan_enrichment_reports_every_missing_credential():
+    # scene + default supabase, empty env -> both the supabase and lastfm checks fire
+    store, audio, tag, errors = plan_enrichment(_analyze_args("--with-scene"), {})
+    assert store is None
+    assert len(errors) == 2
+
+
+# --------------------------------------------------------------------------- #
+# analyze command — fail-fast credential gates + end-to-end enrichment wiring
+# --------------------------------------------------------------------------- #
+
+
+def test_cli_analyze_scene_without_key_fails_fast(
+    tmp_path, history_sample_path, capsys, monkeypatch
+):
+    monkeypatch.delenv("LASTFM_API_KEY", raising=False)
+    shutil.copy(history_sample_path, tmp_path / "history.jsonl")
+    rc = main(
+        [
+            "analyze",
+            "--user-id",
+            "petr",
+            "--data-dir",
+            str(tmp_path),
+            "--with-scene",
+            "--shared-store",
+            "memory",
+        ]
+    )
+    assert rc == 2
+    assert "LASTFM_API_KEY" in capsys.readouterr().out
+    # fail-fast: nothing was analysed or written
+    assert UserStore(root=tmp_path).latest_profile() is None
+
+
+def test_cli_analyze_supabase_without_creds_fails_fast(
+    tmp_path, history_sample_path, capsys, monkeypatch
+):
+    monkeypatch.delenv("SUPABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_KEY", raising=False)
+    shutil.copy(history_sample_path, tmp_path / "history.jsonl")
+    rc = main(["analyze", "--user-id", "petr", "--data-dir", str(tmp_path), "--with-audio"])
+    assert rc == 2
+    assert "SUPABASE_URL" in capsys.readouterr().out
+    assert UserStore(root=tmp_path).latest_profile() is None
+
+
+def test_cli_analyze_with_scene_runs_enrichment(tmp_path, capsys, monkeypatch):
+    """End-to-end through the CLI with the production Last.fm source swapped for an
+    offline in-memory one: enrichment runs, tags land, scene coverage reflects it.
+    No root validates under default (uncalibrated) thresholds — that is correct
+    until #66 calibration — so the proof of wiring is the coverage, not a root."""
+    tracks = [("metal-band", "Track A"), ("jazz-band", "Track B")]
+    mapping = {(a, n): [TrackTag(tag="scene-tag", weight=1.0, source="lastfm")] for a, n in tracks}
+    events = [
+        ListenEvent(
+            track=TrackRef(name=n, artist=a, mbid=f"mbid-{n}"),
+            played_at=datetime(2025, 1, 1, tzinfo=UTC),
+            source="lastfm",
+        )
+        for a, n in tracks
+    ]
+    (tmp_path / "history.jsonl").write_text(
+        "\n".join(e.model_dump_json() for e in events), encoding="utf-8"
+    )
+    monkeypatch.setenv("LASTFM_API_KEY", "present")
+    monkeypatch.setattr(cli, "LastfmTagSource", lambda: InMemoryTagSource(mapping))
+
+    rc = main(
+        [
+            "analyze",
+            "--user-id",
+            "petr",
+            "--data-dir",
+            str(tmp_path),
+            "--with-scene",
+            "--shared-store",
+            "memory",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "scene=1.00" in out  # every track tagged -> full scene coverage
+    profile = UserStore(root=tmp_path).latest_profile()
+    assert profile is not None
+    assert profile.roots == []  # uncalibrated thresholds: honest-empty roots
+
+
+def test_cli_analyze_with_audio_no_dump_notes_zero_coverage(
+    tmp_path, history_sample_path, capsys, monkeypatch
+):
+    """`--with-audio` with no dump installed is honest low coverage, not an error:
+    rc 0, a snapshot, audio=0.00, and a diagnostic note pointing at the dump env."""
+    monkeypatch.delenv("ACOUSTICBRAINZ_FEATURES_INDEX", raising=False)
+    monkeypatch.delenv("ACOUSTICBRAINZ_DUMP_DIR", raising=False)
+    shutil.copy(history_sample_path, tmp_path / "history.jsonl")
+    rc = main(
+        [
+            "analyze",
+            "--user-id",
+            "petr",
+            "--data-dir",
+            str(tmp_path),
+            "--with-audio",
+            "--shared-store",
+            "memory",
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "audio=0.00" in out
+    assert "note: audio coverage 0" in out


### PR DESCRIPTION
## What

`analyze()` already accepts `shared_store` / `audio_source` / `tag_source` and runs the audio/scene stages opt-in-by-dependency, but `_cmd_analyze` constructed **none** of them — so the `analyze` CLI could only ever emit honest-empty profiles. This wires the production adapters (`AcousticBrainzDump`, `LastfmTagSource`) + a `SharedStore` into the CLI so a real enrichment run can surface roots. Pure connective tissue: **no new domain logic** — pipelines stay locked (#63/#64).

## Changes

- New `analyze` flags: `--with-audio`, `--with-scene`, `--ab-index PATH`, `--shared-store {supabase,memory}` (default `supabase`).
- New pure helper `plan_enrichment(args, env) -> (shared_store, audio_source, tag_source, errors)` — resolves flags against env with **presence-only** credential prechecks (value never read or printed), fully offline / unit-tested.
- `analyze` now prints per-category `coverage:` (audio/scene/temporal).
- `CONTEXT.md`: new "Analyze CLI — enrichment surface (V0)" section.

## Behavior

- **No flag → honest-empty baseline preserved** (regression-guarded by existing CLI tests).
- `--with-scene` without `LASTFM_API_KEY`, or `--shared-store supabase` without `SUPABASE_URL`+`SUPABASE_KEY` → **fail fast**, exit 2, clear message, history/store untouched.
- Missing AcousticBrainz dump → **honest low coverage + diagnostic note**, not an error.
- **No live API / dump / Supabase calls in CI** — `plan_enrichment` matrix is offline; the end-to-end scene test swaps the production source for an in-memory one.

## Test

`ruff` + `pytest` green locally (127 passed). Adds the `plan_enrichment` flag/env matrix, the two fail-fast credential gates, the per-category coverage line, the honest-low-coverage audio path, and an offline end-to-end scene-enrichment run (proves wiring via `scene=1.00` coverage; roots stay empty under uncalibrated thresholds — correct until #66).

Closes #78. Prerequisite for #66 (criteria 2–3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
