### PR TITLE
fix: load .env at CLI startup so documented credential mechanism works

### DIFF
--- a/src/music_intel_mcp/cli.py
+++ b/src/music_intel_mcp/cli.py
@@ -28,6 +28,8 @@ import argparse
 import os
 from collections.abc import Mapping, Sequence
 
+from dotenv import find_dotenv, load_dotenv
+
 from .analyzer import analyze
 from .audio import AcousticBrainzDump, AudioFeatureSource
 from .identity import IdentityCache, IdentityResolver, MusicBrainzIsrcIndex
@@ -247,6 +249,13 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
+    # Populate os.environ from a gitignored .env (the documented credential
+    # mechanism: copy .env.example -> .env, fill in the keys). Anchored on the
+    # invocation directory (usecwd=True) so it works both from a source checkout
+    # and an installed wheel; host env wins (override=False) and a missing .env
+    # is a silent no-op. This is the single load point — every subcommand reads
+    # its credentials through os.environ downstream.
+    load_dotenv(find_dotenv(usecwd=True), override=False)
     parser = build_parser()
     args = parser.parse_args(argv)
     return args.func(args)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,17 @@ FIXTURES = Path(__file__).parent / "fixtures"
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
+@pytest.fixture(autouse=True)
+def _no_real_dotenv(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the suite hermetic. ``cli.main`` loads a ``.env`` at startup; stub
+    that loader to a no-op so tests control the environment purely through
+    ``monkeypatch`` and never read a developer's real ``.env``. A test that
+    needs to exercise the real loader re-points ``cli.load_dotenv`` itself."""
+    import music_intel_mcp.cli as cli
+
+    monkeypatch.setattr(cli, "load_dotenv", lambda *args, **kwargs: False)
+
+
 @pytest.fixture
 def history_sample_path() -> Path:
     return FIXTURES / "history_sample.jsonl"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -238,3 +238,35 @@ def test_cli_analyze_with_audio_no_dump_notes_zero_coverage(
     out = capsys.readouterr().out
     assert "audio=0.00" in out
     assert "note: audio coverage 0" in out
+
+
+def test_cli_main_loads_dotenv_credentials(tmp_path, capsys, monkeypatch):
+    """``main`` loads a gitignored ``.env`` so the documented unblock mechanism
+    works: a ``LASTFM_API_KEY`` present only in ``.env`` (not the host env)
+    clears the ``--with-scene`` fail-fast gate instead of exiting 2.
+
+    This test exercises the *real* loader, re-pointing ``cli.load_dotenv`` back
+    over the hermetic autouse stub."""
+    from dotenv import load_dotenv as real_load_dotenv
+
+    monkeypatch.setattr(cli, "load_dotenv", real_load_dotenv)
+    monkeypatch.delenv("LASTFM_API_KEY", raising=False)  # only .env provides it
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text("LASTFM_API_KEY=x\n", encoding="utf-8")
+    # offline scene source so the gate-pass doesn't reach live Last.fm
+    monkeypatch.setattr(cli, "LastfmTagSource", lambda: InMemoryTagSource({}))
+
+    rc = main(
+        [
+            "analyze",
+            "--user-id",
+            "petr",
+            "--data-dir",
+            str(tmp_path),
+            "--with-scene",
+            "--shared-store",
+            "memory",
+        ]
+    )
+    assert rc == 0  # gate cleared: the key crossed from .env into os.environ
+    assert "LASTFM_API_KEY" not in capsys.readouterr().out  # no fail-fast error


### PR DESCRIPTION
Closes #81

## What

`python-dotenv` is a declared dependency, but `load_dotenv()` was **never called** anywhere — every subcommand read credentials straight from `os.environ`. So the documented credential mechanism (`.env.example` header: *"Copy to .env and fill in"*) silently did nothing. A `LASTFM_API_KEY` placed in `.env` exactly as documented would still trip the `analyze --with-scene` fail-fast gate as "absent" (exit 2) — and that is precisely the path that unblocks #66's first real scene-enrichment run.

## Change

- Wire `load_dotenv(find_dotenv(usecwd=True), override=False)` once at the `main()` entry point.
  - `usecwd=True` → anchored on the invocation directory, so it works from a source checkout **and** an installed wheel (the default `find_dotenv` walks up from `cli.py`, which breaks once the package is installed).
  - `override=False` → host env wins over `.env`, matching the documented contract (*".env (gitignored) or the host env"*).
  - Missing `.env` → silent no-op.
- Single load point — no per-subcommand duplication.

## Test

- `conftest`: autouse fixture neutralises the loader so the suite stays **hermetic** regardless of any developer's local `.env`.
- New test exercises the **real** loader: a `LASTFM_API_KEY` present only in a tmp `.env` (cleared from the host env) clears the `--with-scene` fail-fast gate (`rc 0`, no error), proving the wiring end-to-end.
- `ruff` + `pytest` green locally (**128 passed**). No new domain logic — pure connective tissue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
