### PR TITLE
fix: chunk SupabaseSharedStore bulk in.()/upsert (#83)

### DIFF
--- a/src/music_intel_mcp/shared_store.py
+++ b/src/music_intel_mcp/shared_store.py
@@ -41,6 +41,22 @@ DEFAULT_TTL_DAYS = 90
 _SUPABASE_URL_ENV = "SUPABASE_URL"
 _SUPABASE_KEY_ENV = "SUPABASE_KEY"
 
+# PostgREST inlines an ``in.()`` filter into the URL query string, so a bulk read
+# of N ids becomes one URL holding all N — past httpx's 65536-char limit on a
+# realistic library (tens of thousands of tracks). Split bulk reads into id
+# chunks below that ceiling; writes (POST body, no URL limit) chunk only to keep
+# request bodies and the per-row work bounded. Both are *internal* to the store —
+# the caller still issues one logical ``get_tracks``/``upsert_tracks``, so the
+# pull-and-cache no-round-trip invariant (caller-level, not HTTP-level) holds.
+_READ_CHUNK = 100
+_WRITE_CHUNK = 500
+
+
+def _chunked(seq: Sequence, size: int):
+    """Yield ``seq`` in contiguous chunks of at most ``size`` (size ≥ 1)."""
+    for start in range(0, len(seq), size):
+        yield seq[start : start + size]
+
 
 # --------------------------------------------------------------------------- #
 # Canonical track identity
@@ -220,9 +236,17 @@ class SupabaseSharedStore:  # pragma: no cover - network-only, never run in CI
         if not ids:
             return {}
         client = self.client
-        tracks = client.table("tracks").select("*").in_("id", ids).execute().data
-        feats = client.table("audio_features").select("*").in_("track_id", ids).execute().data
-        tags = client.table("tags").select("*").in_("track_id", ids).execute().data
+        tracks: list[dict] = []
+        feats: list[dict] = []
+        tags: list[dict] = []
+        # One ``.in_()`` per id-chunk per table (chunk keeps each URL under the
+        # httpx limit); rows accumulate across chunks before assembly.
+        for chunk in _chunked(ids, _READ_CHUNK):
+            tracks.extend(client.table("tracks").select("*").in_("id", chunk).execute().data)
+            feats.extend(
+                client.table("audio_features").select("*").in_("track_id", chunk).execute().data
+            )
+            tags.extend(client.table("tags").select("*").in_("track_id", chunk).execute().data)
 
         feat_by_id = {f["track_id"]: f for f in feats}
         tags_by_id: dict[str, list[dict]] = {}
@@ -253,34 +277,34 @@ class SupabaseSharedStore:  # pragma: no cover - network-only, never run in CI
         if not records:
             return
         client = self.client
-        client.table("tracks").upsert(
-            [
-                {
-                    "id": r.track_id,
-                    "spotify_id": r.spotify_id,
-                    "isrc": r.isrc,
-                    "mbid": r.mbid,
-                    "name": r.name,
-                    "artist": r.artist,
-                    "fetched_at": r.fetched_at.isoformat(),
-                }
-                for r in records
-            ]
-        ).execute()
+        track_rows = [
+            {
+                "id": r.track_id,
+                "spotify_id": r.spotify_id,
+                "isrc": r.isrc,
+                "mbid": r.mbid,
+                "name": r.name,
+                "artist": r.artist,
+                "fetched_at": r.fetched_at.isoformat(),
+            }
+            for r in records
+        ]
+        for chunk in _chunked(track_rows, _WRITE_CHUNK):
+            client.table("tracks").upsert(chunk).execute()
         feat_rows = [
             {"track_id": r.track_id, **_audio_cols(r.audio_features.model_dump())}
             for r in records
             if r.audio_features is not None
         ]
-        if feat_rows:
-            client.table("audio_features").upsert(feat_rows).execute()
+        for chunk in _chunked(feat_rows, _WRITE_CHUNK):
+            client.table("audio_features").upsert(chunk).execute()
         tag_rows = [
             {"track_id": r.track_id, "tag": t.tag, "weight": t.weight, "source": t.source}
             for r in records
             for t in r.tags
         ]
-        if tag_rows:
-            client.table("tags").upsert(tag_rows, on_conflict="track_id,tag,source").execute()
+        for chunk in _chunked(tag_rows, _WRITE_CHUNK):
+            client.table("tags").upsert(chunk, on_conflict="track_id,tag,source").execute()
 
 
 def _audio_cols(data: dict) -> dict:  # pragma: no cover - used only by Supabase path

--- a/tests/test_shared_store.py
+++ b/tests/test_shared_store.py
@@ -12,11 +12,15 @@ from pydantic import ValidationError
 
 from music_intel_mcp.models import TrackRef
 from music_intel_mcp.shared_store import (
+    _READ_CHUNK,
+    _WRITE_CHUNK,
     AudioFeatures,
     InMemorySharedStore,
     MetadataCache,
+    SupabaseSharedStore,
     TrackMetadataRecord,
     TrackTag,
+    _chunked,
     canonical_track_id,
     is_stale,
     pull_and_cache,
@@ -200,3 +204,97 @@ def test_pull_store_entry_past_ttl_flagged_stale(tmp_path):
     assert result.stale == ["spotify:A"]
     assert result.pulled == []
     assert "spotify:A" in result.records  # still usable for partial analysis
+
+
+# --- SupabaseSharedStore bulk chunking (#83) ------------------------------- #
+
+
+def test_chunked_helper_boundaries():
+    assert list(_chunked(list(range(5)), 2)) == [[0, 1], [2, 3], [4]]
+    assert list(_chunked([], 2)) == []
+    assert list(_chunked([1, 2], 5)) == [[1, 2]]
+
+
+class _FakeResult:
+    def __init__(self, data: list[dict]) -> None:
+        self.data = data
+
+    def execute(self) -> _FakeResult:
+        return self
+
+
+class _FakeTableQuery:
+    """Mimics the postgrest builder chain for one table, recording every
+    ``.in_()`` chunk and ``.upsert()`` chunk on the parent fake client."""
+
+    def __init__(self, name: str, client: _FakeClient) -> None:
+        self._name = name
+        self._client = client
+
+    def select(self, *_cols: str) -> _FakeTableQuery:
+        return self
+
+    def in_(self, col: str, ids: list[str]) -> _FakeResult:
+        self._client.in_calls.setdefault(self._name, []).append(list(ids))
+        match = set(ids)
+        rows = [r for r in self._client.rows.get(self._name, []) if r.get(col) in match]
+        return _FakeResult(rows)
+
+    def upsert(self, rows: list[dict], on_conflict: str | None = None) -> _FakeResult:
+        self._client.upserts.setdefault(self._name, []).append(list(rows))
+        return _FakeResult(list(rows))
+
+
+class _FakeClient:
+    def __init__(self, rows: dict[str, list[dict]] | None = None) -> None:
+        self.rows = rows or {}
+        self.in_calls: dict[str, list[list[str]]] = {}
+        self.upserts: dict[str, list[list[dict]]] = {}
+
+    def table(self, name: str) -> _FakeTableQuery:
+        return _FakeTableQuery(name, self)
+
+
+def test_supabase_get_tracks_chunks_and_merges():
+    """A bulk read past the read-chunk size splits into ≤_READ_CHUNK `.in_()`
+    calls per table (keeping each URL under the httpx limit) and merges rows +
+    audio_features + tags back into one record map."""
+    n = _READ_CHUNK * 2 + 50  # 250 with the default chunk of 100
+    track_rows = [
+        {"id": f"spotify:{i}", "name": f"S{i}", "artist": "A", "fetched_at": T0.isoformat()}
+        for i in range(n)
+    ]
+    feat_rows = [{"track_id": "spotify:7", "bpm": 120.0, "energy": 0.8, "source": "ab"}]
+    tag_rows = [{"track_id": "spotify:9", "tag": "dream pop", "weight": 0.9, "source": "lastfm"}]
+    fake = _FakeClient({"tracks": track_rows, "audio_features": feat_rows, "tags": tag_rows})
+
+    got = SupabaseSharedStore(client=fake).get_tracks([f"spotify:{i}" for i in range(n)])
+
+    assert len(got) == n
+    for table in ("tracks", "audio_features", "tags"):
+        assert [len(c) for c in fake.in_calls[table]] == [_READ_CHUNK, _READ_CHUNK, 50]
+    assert got["spotify:7"].audio_features.bpm == 120.0
+    assert got["spotify:9"].tags[0].tag == "dream pop"
+
+
+def test_supabase_upsert_chunks_large_writes():
+    """Writes past the write-chunk size split into ≤_WRITE_CHUNK-row upserts per
+    table; empty derived tables (no audio_features here) are not written."""
+    n = _WRITE_CHUNK + 100  # 600 with the default chunk of 500
+    recs = [
+        TrackMetadataRecord(
+            track_id=f"spotify:{i}",
+            name=f"S{i}",
+            artist="A",
+            tags=[TrackTag(tag="t", weight=1.0, source="lastfm")],
+            fetched_at=T0,
+        )
+        for i in range(n)
+    ]
+    fake = _FakeClient()
+
+    SupabaseSharedStore(client=fake).upsert_tracks(recs)
+
+    assert [len(c) for c in fake.upserts["tracks"]] == [_WRITE_CHUNK, 100]
+    assert [len(c) for c in fake.upserts["tags"]] == [_WRITE_CHUNK, 100]
+    assert "audio_features" not in fake.upserts


### PR DESCRIPTION
## What

Chunk `SupabaseSharedStore`'s bulk `in.()` reads and upserts so a realistic library no longer overflows httpx's URL limit.

## Why

`get_tracks` inlined **every** id into one PostgREST `in.()` filter:

```python
client.table("tracks").select("*").in_("id", ids).execute()
```

`analyzer._group_and_seed` passes the full unique-track set in one call. On my real history (21,118 unique tracks) the URL blows past httpx's `MAX_URL_LENGTH` (65536):

```
httpx.InvalidURL: URL component 'query' too long
```

So `analyze --with-scene --shared-store supabase` crashes **before any enrichment runs**. CI never caught it — it uses `InMemorySharedStore`, and the crit-1 real run (#76/#77) was the honest-empty baseline that does no store reads. This blocks #66 (real scene roots → calibration).

## Fix

- `get_tracks`: split ids into ≤100-id chunks, one `.in_()` per chunk per table, merge rows + audio_features + tags.
- `upsert_tracks`: chunk each table's rows (≤500/upsert).

Internal to the store — callers still issue one logical `get_tracks`/`upsert_tracks`, so the pull-and-cache no-round-trip invariant (caller-level, not HTTP-level) is unchanged.

## Tests

- `_chunked` boundary cases.
- `get_tracks` over 250 ids → 3 chunked `.in_()` calls per table + merged records (fake client via the existing constructor injection point).
- `upsert_tracks` over 600 records → 2 chunked upserts per table; empty derived tables not written.

Full suite green (131 passed).

Closes #83
