### PR TITLE
ci: add [no-issue] and refactor: lanes to require-linked-issue gate

### DIFF
--- a/.github/workflows/pr-body-check.yml
+++ b/.github/workflows/pr-body-check.yml
@@ -32,11 +32,23 @@ jobs:
               return;
             }
 
+            // Drive-by lane: explicit [no-issue] marker for artifact/fix-inline PRs (jarvis#428).
+            if (/\[no-issue\]/i.test(body)) {
+              console.log('[no-issue] marker — skipping linked-issue requirement (drive-by).');
+              return;
+            }
+
+            // Refactor lane: refactor: / refactor(scope): title prefix.
+            if (/^refactor(\([^)]*\))?:/i.test(pr.title || '')) {
+              console.log('refactor: title prefix — skipping linked-issue requirement.');
+              return;
+            }
+
             const issueMatches = [...body.matchAll(/(?:closes|fixes|resolves)\s+#(\d+)/gi)];
             const issueNumbers = [...new Set(issueMatches.map(m => parseInt(m[1], 10)))];
 
             if (issueNumbers.length === 0) {
-              core.setFailed('PR body must include a linked issue reference (e.g. "Closes #123"). For hotfixes, apply the priority:critical label instead.');
+              core.setFailed('PR body must include a linked issue reference (e.g. "Closes #123"). Alternatives: priority:critical label (hotfix), a [no-issue] body marker (drive-by/artifact PR), or a refactor: title prefix.');
               return;
             }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Before marking any task complete:
 
 ## Process
 
-- **Branches** from `main`. One issue → one PR. PR body must `Closes #NNN` or carry the `priority:critical` label (hotfix bypass, mirrors jarvis pattern).
+- **Branches** from `main`. One issue → one PR. PR body must `Closes #NNN`, or carry the `priority:critical` label (hotfix), or contain a `[no-issue]` body marker (drive-by / artifact PRs, e.g. grill CONTEXT.md notes), or use a `refactor:` / `refactor(scope):` title prefix — the four lanes of the universal owned-repo contract (jarvis#428).
 - **Decisions** belong in memory (`record_decision`), not in PR bodies or markdown files. CONTEXT.md captures *resolved* state; ephemeral debate goes to GitHub Discussions.
 - **TDD where the domain decides correctness** — recommendation scoring, similarity, anti-bubble penalty, importers. Write the failing test that defines "right answer" before the implementation.
 - **Vertical slices, not horizontal.** Each issue ships end-to-end (data → logic → test → CLI/output). Don't do "all loaders, then all scoring, then all output".


### PR DESCRIPTION
Closes #100

Aligns `pr-body-check.yml` with the universal owned-repo contract (jarvis#428): four lanes instead of two.

- `[no-issue]` body marker (case-insensitive) — drive-by / artifact PRs that must not close an issue (hit in practice: #99, a grill CONTEXT.md note for #95 that ships ahead of #95's implementation PR).
- `refactor:` / `refactor(scope):` title prefix.
- Failure message now names all lanes; CLAUDE.md Process bullet documents them.

Existing lanes (linked issue, `priority:critical`, bot authors) unchanged. Bypass checks run before the issue-existence check, mirroring the original control flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)