### PR TITLE
feat(audio): onnxruntime/librosa engine footprint benchmark (#123)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,16 @@ dev = [
 supabase = [
   "supabase>=2.0",
 ]
+# onnxruntime/librosa engine benchmark (#123, decision 16d7f570). Downloads real
+# ONNX model binaries and does real inference — never exercised by the default
+# unit-test suite, so this stays out of dev/default install.
+onnx-bench = [
+  "onnxruntime>=1.17",
+  "librosa>=0.10",
+  # Cross-platform peak-RSS sampling; stdlib `resource` is POSIX-only and
+  # unusable on this Windows-primary dev machine.
+  "psutil>=5.9",
+]
 
 [project.scripts]
 music-intel = "music_intel_mcp.cli:main"

--- a/scripts/benchmark_onnx_engine.py
+++ b/scripts/benchmark_onnx_engine.py
@@ -1,0 +1,428 @@
+"""Spike B (#123): onnxruntime/librosa engine footprint + throughput benchmark.
+
+Runs the full MTG inference chain locked by decision ``16d7f570`` (Discogs-EffNet
+embedding -> MTG-Jamendo classifier head, both consumed as ONNX via
+``onnxruntime``, with ``librosa`` as the mel-spectrogram frontend) over a batch
+of representative synthetic audio clips, and reports whether the chain is cheap
+enough to run continuously alongside real-time playback (#109 AC "Spike B").
+
+No live capture and no copyrighted audio are needed (issue body, explicitly):
+clips are synthetic (harmonic tones + noise, duration drawn from a realistic
+track-length distribution) so nothing audio-derived is committed to the repo.
+This is a footprint/throughput spike, not the ``timbre`` enricher itself — the
+mel-spectrogram frontend below approximates Essentia's own
+``TensorflowPredictEffnetDiscogs`` preprocessing (same sample rate, mel-band
+count and patch shape) closely enough to drive realistic FLOPs/memory through
+the real ONNX graphs, but is not claimed bit-exact; exact frontend fidelity is
+in scope for the future enricher implementation, not this spike.
+
+Model files are downloaded on first run into ``.scratch/onnx_models/``
+(gitignored — binaries are never committed, matching the AcousticBrainz/
+MusicBrainz dump convention) and verified against the SHA-256 hashes pinned in
+``MODELS`` below, captured from https://essentia.upf.edu/models/ on
+2026-08-19 (CC BY-NC-ND 4.0 per that directory's LICENSE file; local-only use
+here matches the storage/licensing gate in decision ``29852699``).
+
+Usage::
+
+    python scripts/benchmark_onnx_engine.py --n-clips 50 --out .scratch/onnx_bench_report.json
+
+The report is written to a local, never-committed path; only the summary
+(printed to stdout and pasted into the issue) is meant to be shared.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import statistics
+import threading
+import time
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+SAMPLE_RATE = 16_000  # required by both ONNX graphs (models' "inference.sample_rate")
+N_MELS = 96
+PATCH_FRAMES = 128
+N_FFT = 1024
+HOP_LENGTH = 256
+
+# Pinned model provenance (AC4: exact source + version, reproducible). Captured
+# from the essentia.upf.edu directory listing + per-model .json metadata on
+# 2026-08-19. sha256 values are filled in lazily on first successful download
+# (recorded into the report) rather than hand-computed here, since pinning an
+# unverified hash defeats the point of verification.
+MODELS: dict[str, dict[str, str]] = {
+    "embedding": {
+        "name": "discogs-effnet-bsdynamic-1",
+        "role": "Discogs-EffNet audio embedding (feature extractor)",
+        "url": (
+            "https://essentia.upf.edu/models/feature-extractors/discogs-effnet/"
+            "discogs-effnet-bsdynamic-1.onnx"
+        ),
+        "version": "1",
+        "release_date": "2022-02-17",
+        "framework": "ONNX",
+        "framework_version": "1.10.1",
+        "license": (
+            "CC BY-NC-ND 4.0 (essentia.upf.edu/models/LICENSE) — local-only per decision 29852699"
+        ),
+        # Actual ONNX graph input name, confirmed via onnxruntime InferenceSession
+        # against the downloaded file — the essentia.upf.edu .json metadata
+        # sidecar advertises a different (serving-signature) name that doesn't
+        # match the graph itself.
+        "input_name": "melspectrogram",
+        "sample_rate": str(SAMPLE_RATE),
+    },
+    "classifier_head": {
+        "name": "mtg_jamendo_genre-discogs-effnet-1",
+        "role": "MTG-Jamendo genre classifier head (consumes Discogs-EffNet embeddings)",
+        "url": (
+            "https://essentia.upf.edu/models/classification-heads/mtg_jamendo_genre/"
+            "mtg_jamendo_genre-discogs-effnet-1.onnx"
+        ),
+        "version": "1",
+        "release_date": "2022-11-20",
+        "framework": "ONNX (converted from TensorFlow 2.8.0)",
+        "framework_version": "1.10.1",
+        "license": (
+            "CC BY-NC-ND 4.0 (essentia.upf.edu/models/LICENSE) — local-only per decision 29852699"
+        ),
+        # See the "melspectrogram" comment above — same discrepancy applies here.
+        "input_name": "embeddings",
+        "sample_rate": str(SAMPLE_RATE),
+    },
+}
+
+DEFAULT_CACHE_DIR = Path(".scratch/onnx_models")
+
+# Realistic track-length distribution for synthetic clips (seconds): most pop/
+# rock tracks land 2:30-4:30, with a long tail of shorter/longer material.
+_DURATION_BUCKETS_S = (90, 150, 180, 210, 240, 270, 300, 360, 480)
+
+
+# --------------------------------------------------------------------------- #
+# Model download + verification (network — not exercised by unit tests)
+# --------------------------------------------------------------------------- #
+
+
+def ensure_model(spec: dict[str, str], cache_dir: Path) -> tuple[Path, str]:
+    """Download ``spec['url']`` into ``cache_dir`` if not already present, return
+    (local path, sha256 hex digest). Re-downloads are skipped once the file
+    exists — this benchmark cares about steady-state inference cost, not
+    download time."""
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    dest = cache_dir / Path(spec["url"]).name
+    if not dest.exists():
+        with urllib.request.urlopen(spec["url"], timeout=60) as resp:  # noqa: S310 - pinned https URL
+            dest.write_bytes(resp.read())
+    digest = hashlib.sha256(dest.read_bytes()).hexdigest()
+    return dest, digest
+
+
+# --------------------------------------------------------------------------- #
+# Synthetic clip generation (no copyrighted audio; nothing here is committed)
+# --------------------------------------------------------------------------- #
+
+
+def synthetic_clip(duration_s: float, *, seed: int, sample_rate: int = 44_100):
+    """A harmonic-tone + noise mixture standing in for a "representative" music
+    clip. Real timbral content doesn't matter for a footprint/throughput
+    measurement (the ONNX graphs run the same FLOPs regardless of input
+    semantics) -- what matters is realistic duration and a non-degenerate
+    (non-silent, non-constant) waveform so librosa's mel/STFT path does real
+    work rather than short-circuiting on silence."""
+    import numpy as np
+
+    rng = np.random.default_rng(seed)
+    n_samples = int(duration_s * sample_rate)
+    t = np.arange(n_samples) / sample_rate
+    fundamental = rng.uniform(110.0, 440.0)
+    wave = np.zeros(n_samples, dtype=np.float64)
+    for harmonic, amplitude in ((1, 1.0), (2, 0.5), (3, 0.25), (4, 0.125)):
+        wave += amplitude * np.sin(2 * np.pi * fundamental * harmonic * t)
+    wave += 0.05 * rng.standard_normal(n_samples)
+    wave /= np.max(np.abs(wave)) + 1e-9
+    return wave.astype(np.float32), sample_rate
+
+
+def sample_clip_durations(n_clips: int, *, seed: int = 0) -> list[float]:
+    """Draw ``n_clips`` durations from :data:`_DURATION_BUCKETS_S`, deterministic
+    per seed so repeat runs are comparable."""
+    import numpy as np
+
+    rng = np.random.default_rng(seed)
+    return [float(rng.choice(_DURATION_BUCKETS_S)) for _ in range(n_clips)]
+
+
+# --------------------------------------------------------------------------- #
+# Frontend: waveform -> mel-spectrogram patches (approximates the Discogs-
+# EffNet preprocessing: 16 kHz, 96 mel bands, 128-frame patches)
+# --------------------------------------------------------------------------- #
+
+
+def waveform_to_patches(wave, sample_rate: int):
+    """Resample to :data:`SAMPLE_RATE`, compute a log-mel spectrogram, and slice
+    it into non-overlapping ``[PATCH_FRAMES, N_MELS]`` patches (zero-padding the
+    final partial patch). Returns a ``[n_patches, PATCH_FRAMES, N_MELS]``
+    float32 array matching the embedding model's declared input shape."""
+    import librosa
+    import numpy as np
+
+    if sample_rate != SAMPLE_RATE:
+        wave = librosa.resample(wave, orig_sr=sample_rate, target_sr=SAMPLE_RATE)
+
+    mel = librosa.feature.melspectrogram(
+        y=wave, sr=SAMPLE_RATE, n_fft=N_FFT, hop_length=HOP_LENGTH, n_mels=N_MELS
+    )
+    log_mel = librosa.power_to_db(mel).T.astype(np.float32)  # [n_frames, N_MELS]
+
+    n_frames = log_mel.shape[0]
+    n_patches = max(1, -(-n_frames // PATCH_FRAMES))  # ceil div
+    padded_len = n_patches * PATCH_FRAMES
+    if padded_len > n_frames:
+        pad = np.zeros((padded_len - n_frames, N_MELS), dtype=np.float32)
+        log_mel = np.concatenate([log_mel, pad], axis=0)
+
+    return log_mel.reshape(n_patches, PATCH_FRAMES, N_MELS)
+
+
+# --------------------------------------------------------------------------- #
+# Inference chain
+# --------------------------------------------------------------------------- #
+
+
+def build_sessions(embedding_path: Path, classifier_path: Path):
+    import onnxruntime as ort
+
+    opts = ort.SessionOptions()
+    opts.intra_op_num_threads = 1  # single-track-at-a-time is the real usage pattern
+    embedding_session = ort.InferenceSession(
+        str(embedding_path), sess_options=opts, providers=["CPUExecutionProvider"]
+    )
+    classifier_session = ort.InferenceSession(
+        str(classifier_path), sess_options=opts, providers=["CPUExecutionProvider"]
+    )
+    return embedding_session, classifier_session
+
+
+def run_chain(embedding_session, classifier_session, patches) -> Any:
+    """Embedding model -> mean-pool over patches -> classifier head. Returns the
+    classifier's sigmoid predictions (unused beyond proving the chain runs
+    end-to-end; this spike measures cost, not accuracy)."""
+    import numpy as np
+
+    embedding_input = MODELS["embedding"]["input_name"]
+    embedding_output_name = embedding_session.get_outputs()[-1].name  # "embeddings" output
+    (embeddings,) = embedding_session.run([embedding_output_name], {embedding_input: patches})
+    pooled = embeddings.mean(axis=0, keepdims=True).astype(np.float32)  # [1, 1280]
+
+    classifier_input = MODELS["classifier_head"]["input_name"]
+    (predictions,) = classifier_session.run(None, {classifier_input: pooled})
+    return predictions
+
+
+# --------------------------------------------------------------------------- #
+# Memory sampling (cross-platform peak RSS -- Windows has no `resource` module)
+# --------------------------------------------------------------------------- #
+
+
+class PeakRssSampler:
+    """Background-thread sampler of the current process's RSS, polled at a fixed
+    interval. ``psutil`` works identically on Windows/Linux/macOS, unlike the
+    stdlib ``resource`` module (POSIX-only, unusable on this Windows-primary
+    product)."""
+
+    def __init__(self, interval_s: float = 0.05):
+        self._interval_s = interval_s
+        self._peak_bytes = 0
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def _poll(self) -> None:
+        import psutil
+
+        process = psutil.Process()
+        while not self._stop.is_set():
+            rss = process.memory_info().rss
+            if rss > self._peak_bytes:
+                self._peak_bytes = rss
+            self._stop.wait(self._interval_s)
+
+    def __enter__(self) -> PeakRssSampler:
+        import psutil
+
+        self._peak_bytes = psutil.Process().memory_info().rss
+        self._thread = threading.Thread(target=self._poll, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=self._interval_s * 4)
+
+    @property
+    def peak_mb(self) -> float:
+        return self._peak_bytes / (1024 * 1024)
+
+
+# --------------------------------------------------------------------------- #
+# Report assembly (pure logic -- unit-tested without real models/audio)
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class ClipResult:
+    duration_s: float
+    latency_s: float
+
+
+@dataclass
+class BenchmarkReport:
+    n_clips: int
+    p50_latency_s: float
+    p95_latency_s: float
+    mean_latency_s: float
+    peak_rss_mb: float
+    realtime_ratio_p95: float  # p95 latency / shortest sampled clip duration
+    sustainable: bool
+    models: dict[str, dict[str, str]] = field(default_factory=dict)
+    clips: list[ClipResult] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "n_clips": self.n_clips,
+            "p50_latency_s": self.p50_latency_s,
+            "p95_latency_s": self.p95_latency_s,
+            "mean_latency_s": self.mean_latency_s,
+            "peak_rss_mb": self.peak_rss_mb,
+            "realtime_ratio_p95": self.realtime_ratio_p95,
+            "sustainable": self.sustainable,
+            "models": self.models,
+            "clips": [{"duration_s": c.duration_s, "latency_s": c.latency_s} for c in self.clips],
+        }
+
+
+# Thresholds for the "sustainable alongside real-time playback" verdict (AC3).
+# Real-time headroom: the whole chain for one clip must finish in a small
+# fraction of that clip's own duration (playback keeps running the whole time
+# regardless, so there's no hard deadline -- but a ratio near or above 1.0
+# means analysis falls behind the listening pace on a live/backfill queue).
+# Memory: kept well under what's realistically "spare" during normal desktop
+# use (browser + player + background apps) on typical consumer hardware.
+REALTIME_RATIO_CEILING = 0.5
+PEAK_RSS_CEILING_MB = 1500.0
+
+
+def percentile(values: list[float], pct: float) -> float:
+    if not values:
+        raise ValueError("percentile of empty sequence")
+    ordered = sorted(values)
+    k = (len(ordered) - 1) * (pct / 100.0)
+    lo, hi = int(k), min(int(k) + 1, len(ordered) - 1)
+    if lo == hi:
+        return ordered[lo]
+    return ordered[lo] + (ordered[hi] - ordered[lo]) * (k - lo)
+
+
+def build_report(
+    clips: list[ClipResult], peak_rss_mb: float, models: dict[str, dict[str, str]]
+) -> BenchmarkReport:
+    latencies = [c.latency_s for c in clips]
+    p50 = percentile(latencies, 50)
+    p95 = percentile(latencies, 95)
+    shortest_duration = min(c.duration_s for c in clips)
+    realtime_ratio_p95 = p95 / shortest_duration
+    sustainable = (
+        realtime_ratio_p95 <= REALTIME_RATIO_CEILING and peak_rss_mb <= PEAK_RSS_CEILING_MB
+    )
+    return BenchmarkReport(
+        n_clips=len(clips),
+        p50_latency_s=p50,
+        p95_latency_s=p95,
+        mean_latency_s=statistics.mean(latencies),
+        peak_rss_mb=peak_rss_mb,
+        realtime_ratio_p95=realtime_ratio_p95,
+        sustainable=sustainable,
+        models=models,
+        clips=clips,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+
+def run_benchmark(n_clips: int, cache_dir: Path, seed: int = 0) -> BenchmarkReport:
+    embedding_path, embedding_sha256 = ensure_model(MODELS["embedding"], cache_dir)
+    classifier_path, classifier_sha256 = ensure_model(MODELS["classifier_head"], cache_dir)
+    embedding_session, classifier_session = build_sessions(embedding_path, classifier_path)
+
+    models = {
+        key: {**spec, "sha256": digest}
+        for key, spec, digest in (
+            ("embedding", MODELS["embedding"], embedding_sha256),
+            ("classifier_head", MODELS["classifier_head"], classifier_sha256),
+        )
+    }
+
+    durations = sample_clip_durations(n_clips, seed=seed)
+    clips: list[ClipResult] = []
+    with PeakRssSampler() as sampler:
+        for i, duration_s in enumerate(durations):
+            wave, sample_rate = synthetic_clip(duration_s, seed=seed * 1000 + i)
+            start = time.perf_counter()
+            patches = waveform_to_patches(wave, sample_rate)
+            run_chain(embedding_session, classifier_session, patches)
+            latency_s = time.perf_counter() - start
+            clips.append(ClipResult(duration_s=duration_s, latency_s=latency_s))
+        peak_rss_mb = sampler.peak_mb
+
+    return build_report(clips, peak_rss_mb, models)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--n-clips", type=int, default=50, help="number of synthetic clips (AC1: >=50)"
+    )
+    parser.add_argument(
+        "--cache-dir", default=str(DEFAULT_CACHE_DIR), help="local ONNX model cache (gitignored)"
+    )
+    parser.add_argument("--seed", type=int, default=0, help="deterministic synthetic-clip seed")
+    parser.add_argument(
+        "--out", required=True, help="output report path (local file, never committed)"
+    )
+    args = parser.parse_args(argv)
+
+    if args.n_clips < 50:
+        print(f"AC1 requires >=50 clips; got --n-clips={args.n_clips}")
+        return 1
+
+    report = run_benchmark(args.n_clips, Path(args.cache_dir), seed=args.seed)
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(report.to_dict(), indent=2), encoding="utf-8")
+
+    verdict = "SUSTAINABLE" if report.sustainable else "NOT SUSTAINABLE"
+    print(f"wrote benchmark report to {out_path}")
+    print(
+        f"  n_clips={report.n_clips} p50={report.p50_latency_s:.3f}s "
+        f"p95={report.p95_latency_s:.3f}s mean={report.mean_latency_s:.3f}s "
+        f"peak_rss={report.peak_rss_mb:.1f}MB realtime_ratio_p95={report.realtime_ratio_p95:.4f}"
+    )
+    print(
+        f"  verdict: {verdict} (real-time ratio ceiling={REALTIME_RATIO_CEILING}, "
+        f"peak RSS ceiling={PEAK_RSS_CEILING_MB}MB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_onnx_engine.py
+++ b/scripts/benchmark_onnx_engine.py
@@ -18,10 +18,13 @@ in scope for the future enricher implementation, not this spike.
 
 Model files are downloaded on first run into ``.scratch/onnx_models/``
 (gitignored — binaries are never committed, matching the AcousticBrainz/
-MusicBrainz dump convention) and verified against the SHA-256 hashes pinned in
-``MODELS`` below, captured from https://essentia.upf.edu/models/ on
-2026-08-19 (CC BY-NC-ND 4.0 per that directory's LICENSE file; local-only use
-here matches the storage/licensing gate in decision ``29852699``).
+MusicBrainz dump convention), and their SHA-256 is recorded into the report
+for provenance/reproducibility (AC4) — trust-on-first-use, not verification
+against a pinned expected hash (no expected hash is pinned in ``MODELS``; see
+the comment above that dict for why). Sourced from
+https://essentia.upf.edu/models/ on 2026-08-19 (CC BY-NC-ND 4.0 per that
+directory's LICENSE file; local-only use here matches the storage/licensing
+gate in decision ``29852699``).
 
 Usage::
 
@@ -105,7 +108,7 @@ _DURATION_BUCKETS_S = (90, 150, 180, 210, 240, 270, 300, 360, 480)
 
 
 # --------------------------------------------------------------------------- #
-# Model download + verification (network — not exercised by unit tests)
+# Model download + provenance hashing (network — not exercised by unit tests)
 # --------------------------------------------------------------------------- #
 
 

--- a/tests/test_benchmark_onnx_engine.py
+++ b/tests/test_benchmark_onnx_engine.py
@@ -1,0 +1,174 @@
+"""Unit tests for the onnxruntime/librosa engine benchmark (#123).
+
+Synthetic data only, no network, no real ONNX model download/inference —
+those are exercised once manually as the E2E smoke run (see PR body), not by
+this suite. Covers the pure-Python pieces: percentile math, deterministic
+clip-duration sampling, the sustainability verdict, and the mel-spectrogram
+patch shape (librosa itself is a local computation, no network involved, but
+lives in the optional ``onnx-bench`` extra so its test is skipped when that
+extra isn't installed).
+"""
+
+from __future__ import annotations
+
+import pytest
+from benchmark_onnx_engine import (
+    N_MELS,
+    PATCH_FRAMES,
+    PEAK_RSS_CEILING_MB,
+    REALTIME_RATIO_CEILING,
+    ClipResult,
+    build_report,
+    percentile,
+    sample_clip_durations,
+    synthetic_clip,
+)
+
+# --------------------------------------------------------------------------- #
+# percentile
+# --------------------------------------------------------------------------- #
+
+
+def test_percentile_median_odd_count():
+    assert percentile([1.0, 3.0, 2.0], 50) == 2.0
+
+
+def test_percentile_p95_matches_known_interpolation():
+    values = [float(i) for i in range(1, 101)]  # 1..100
+    # k = (100-1) * 0.95 = 94.05 -> interpolate between index 94 (95.0) and 95 (96.0)
+    assert percentile(values, 95) == pytest.approx(95.05)
+
+
+def test_percentile_single_value():
+    assert percentile([42.0], 50) == 42.0
+    assert percentile([42.0], 95) == 42.0
+
+
+def test_percentile_empty_raises():
+    with pytest.raises(ValueError):
+        percentile([], 50)
+
+
+# --------------------------------------------------------------------------- #
+# sample_clip_durations
+# --------------------------------------------------------------------------- #
+
+
+def test_sample_clip_durations_deterministic_per_seed():
+    a = sample_clip_durations(50, seed=7)
+    b = sample_clip_durations(50, seed=7)
+    assert a == b
+
+
+def test_sample_clip_durations_varies_by_seed():
+    a = sample_clip_durations(50, seed=1)
+    b = sample_clip_durations(50, seed=2)
+    assert a != b
+
+
+def test_sample_clip_durations_count_and_positivity():
+    durations = sample_clip_durations(50, seed=0)
+    assert len(durations) == 50
+    assert all(d > 0 for d in durations)
+
+
+# --------------------------------------------------------------------------- #
+# synthetic_clip
+# --------------------------------------------------------------------------- #
+
+
+def test_synthetic_clip_shape_and_bounds():
+    np = pytest.importorskip("numpy")
+    wave, sample_rate = synthetic_clip(2.0, seed=0, sample_rate=44_100)
+    assert sample_rate == 44_100
+    assert wave.shape == (int(2.0 * 44_100),)
+    assert wave.dtype == np.float32
+    assert float(np.max(np.abs(wave))) <= 1.0 + 1e-6
+
+
+def test_synthetic_clip_deterministic_per_seed():
+    wave_a, _ = synthetic_clip(1.0, seed=3)
+    wave_b, _ = synthetic_clip(1.0, seed=3)
+    assert (wave_a == wave_b).all()
+
+
+def test_synthetic_clip_not_silent():
+    np = pytest.importorskip("numpy")
+    wave, _ = synthetic_clip(1.0, seed=0)
+    assert np.abs(wave).mean() > 0.01
+
+
+# --------------------------------------------------------------------------- #
+# waveform_to_patches (librosa lives in the optional onnx-bench extra)
+# --------------------------------------------------------------------------- #
+
+
+def test_waveform_to_patches_shape():
+    pytest.importorskip("librosa")
+    from benchmark_onnx_engine import SAMPLE_RATE, waveform_to_patches
+
+    wave, sample_rate = synthetic_clip(3.0, seed=0, sample_rate=SAMPLE_RATE)
+    patches = waveform_to_patches(wave, sample_rate)
+    assert patches.ndim == 3
+    assert patches.shape[1] == PATCH_FRAMES
+    assert patches.shape[2] == N_MELS
+    assert patches.shape[0] >= 1
+
+
+def test_waveform_to_patches_resamples_when_needed():
+    pytest.importorskip("librosa")
+    from benchmark_onnx_engine import waveform_to_patches
+
+    wave, sample_rate = synthetic_clip(1.0, seed=0, sample_rate=44_100)
+    patches = waveform_to_patches(wave, sample_rate)
+    assert patches.shape[1:] == (PATCH_FRAMES, N_MELS)
+
+
+# --------------------------------------------------------------------------- #
+# build_report / sustainability verdict
+# --------------------------------------------------------------------------- #
+
+
+def _clips(latencies_and_durations: list[tuple[float, float]]) -> list[ClipResult]:
+    return [ClipResult(duration_s=d, latency_s=lat) for lat, d in latencies_and_durations]
+
+
+def test_build_report_sustainable_when_fast_and_light():
+    clips = _clips([(0.05, 120.0), (0.06, 90.0), (0.07, 180.0)])
+    report = build_report(clips, peak_rss_mb=500.0, models={})
+    assert report.sustainable is True
+    assert report.n_clips == 3
+    assert report.peak_rss_mb == 500.0
+
+
+def test_build_report_not_sustainable_when_latency_exceeds_ceiling():
+    # shortest clip is 90s; p95 latency needs to exceed ratio ceiling * 90s
+    slow_latency = REALTIME_RATIO_CEILING * 90.0 + 1.0
+    clips = _clips([(slow_latency, 90.0), (slow_latency, 90.0), (slow_latency, 90.0)])
+    report = build_report(clips, peak_rss_mb=500.0, models={})
+    assert report.sustainable is False
+
+
+def test_build_report_not_sustainable_when_memory_exceeds_ceiling():
+    clips = _clips([(0.05, 120.0), (0.06, 90.0)])
+    report = build_report(clips, peak_rss_mb=PEAK_RSS_CEILING_MB + 1.0, models={})
+    assert report.sustainable is False
+
+
+def test_build_report_computes_p50_p95_mean():
+    clips = _clips([(0.10, 100.0), (0.20, 100.0), (0.30, 100.0), (0.40, 100.0)])
+    report = build_report(clips, peak_rss_mb=100.0, models={})
+    assert report.p50_latency_s == pytest.approx(percentile([0.10, 0.20, 0.30, 0.40], 50))
+    assert report.p95_latency_s == pytest.approx(percentile([0.10, 0.20, 0.30, 0.40], 95))
+    assert report.mean_latency_s == pytest.approx(0.25)
+
+
+def test_report_to_dict_round_trips_fields():
+    clips = _clips([(0.05, 120.0), (0.06, 90.0)])
+    report = build_report(clips, peak_rss_mb=321.0, models={"embedding": {"url": "x"}})
+    data = report.to_dict()
+    assert data["n_clips"] == 2
+    assert data["peak_rss_mb"] == 321.0
+    assert data["models"] == {"embedding": {"url": "x"}}
+    assert len(data["clips"]) == 2
+    assert data["clips"][0] == {"duration_s": 120.0, "latency_s": 0.05}


### PR DESCRIPTION
## Summary
Adds `scripts/benchmark_onnx_engine.py`, a standalone benchmark that runs the full MTG inference chain (Discogs-EffNet embedding -> MTG-Jamendo genre classifier head, both ONNX via `onnxruntime`, mel-spectrogram frontend via `librosa`) over 50 synthetic audio clips and reports P50/P95 latency, peak RSS, and a sustainability verdict.

## Why
Spike B for #109 (audio-decomposition/timbre design). The engine choice (onnxruntime + librosa) was locked by decision `16d7f570`, but nobody had actually measured whether running it is cheap enough to do continuously alongside real-time playback. This spike answers that with real numbers instead of assumption.

Closes #123

## Decisions & Alternatives
- **Synthetic audio clips, not real tracks** вЂ” the ONNX graphs' cost is a function of input shape/duration, not musical content, and the issue body explicitly allows static fixtures. Avoids committing copyrighted audio or depending on external sample libraries.
- **`psutil` for peak RSS, not stdlib `resource`** вЂ” `resource` is POSIX-only and this is a Windows-primary dev machine; `psutil` gives identical semantics cross-platform. Sampled via a background polling thread rather than a single before/after read, since the peak can occur mid-inference.
- **Model input/output names corrected from what the essentia.upf.edu `.json` metadata sidecars advertised** вЂ” the sidecars report serving-signature names (`serving_default_melspectrogram`, `model/Placeholder`) that don't match the actual ONNX graph (`melspectrogram`, `embeddings`). Found this by loading the real downloaded files with `onnxruntime.InferenceSession` and inspecting `get_inputs()/get_outputs()` directly вЂ” the code now sources truth from the graph, with a comment flagging the discrepancy for future model swaps.
- **Real download + real inference is not part of the automated pytest suite** вЂ” network I/O and multi-GB-ish memory footprint don't belong in CI's unit-test loop (repo rule: tests must not call live APIs). The pure-Python pieces (percentile math, deterministic clip sampling, the sustainability verdict, mel-spectrogram patch shape) are unit-tested with synthetic data; the actual model-download-and-inference path was run once manually as an E2E smoke (see Testing below) to get the real numbers this PR reports.
- **`onnx-bench` kept as a separate optional-dependencies extra**, not `dev` вЂ” `onnxruntime`/`librosa`/`psutil` are only needed to run this one script, and dev installs shouldn't drag in a benchmark-only dependency tree.

## Risk Assessment
- **LOW**: new standalone script + tests, no existing code touched, no import-time dependency on the new packages (`onnxruntime`/`librosa`/`psutil` imported lazily inside functions so the module imports cleanly without the `onnx-bench` extra installed).

## Testing
- `ruff check` / `ruff format --check` вЂ” clean
- `pytest tests/test_benchmark_onnx_engine.py -q` вЂ” 17 passed (2 skip gracefully when `librosa` isn't installed, confirmed both paths)
- `pytest -q` (full suite) вЂ” 317 passed, no regressions
- **E2E smoke** (real run, required before claiming this done вЂ” I/O-heavy per the implement skill's gate): `python scripts/benchmark_onnx_engine.py --n-clips 50 --out .scratch/onnx_bench_report.json`, real model download from essentia.upf.edu, real onnxruntime inference over 50 clips. Result:
  ```
  n_clips=50 p50=0.861s p95=1.784s mean=0.964s peak_rss=2467.5MB realtime_ratio_p95=0.0198
  verdict: NOT SUSTAINABLE (real-time ratio ceiling=0.5, peak RSS ceiling=1500.0MB)
  ```
  Latency is a non-issue (P95 is ~2% of the shortest sampled clip's duration). The blocker is memory: 2467.5MB peak RSS for a single-track inference exceeds the 1500MB ceiling chosen for "comfortable alongside a player + browser on typical consumer hardware." Follow-up (not in scope here) would be tuning onnxruntime's session/arena config or evaluating a smaller embedding model before running this chain unattended in the background.

## Files Changed
- `scripts/benchmark_onnx_engine.py` вЂ” the benchmark: model download+SHA256 hash recording (trust-on-first-use, not pinned-hash verification)+cache (`.scratch/onnx_models/`, gitignored), synthetic clip generation, librosa mel-spectrogram frontend, onnxruntime inference chain, peak-RSS sampling, P50/P95/verdict computation, JSON report writer with full model provenance (AC4).
- `tests/test_benchmark_onnx_engine.py` вЂ” synthetic-only, no-network unit tests for the pure-Python helpers.
- `pyproject.toml` вЂ” new `onnx-bench` optional-dependencies extra (`onnxruntime`, `librosa`, `psutil`).
